### PR TITLE
Add some helpers

### DIFF
--- a/src/ListClient.test.ts
+++ b/src/ListClient.test.ts
@@ -47,7 +47,7 @@ describe('list clients', () => {
     expect(finishedAlpha.toArray()).toEqual(['"1"', '2', 3, '']);
   });
 
-  test('list clietns can map over items', () => {
+  test('list clients can map over items', () => {
     const alpha = new InnerListClient(
       checkpoint,
       roomID,

--- a/src/ListClient.test.ts
+++ b/src/ListClient.test.ts
@@ -71,6 +71,20 @@ describe('list clients', () => {
     ]);
   });
 
+  test('list.push supports varags', () => {
+    const alpha = new InnerListClient(
+      checkpoint,
+      roomID,
+      docID,
+      listID,
+      ws,
+      'alpha'
+    );
+
+    const finished = alpha.push(1, 2, 'boogaloo');
+    expect(finished.toArray()).toEqual([1, 2, 'boogaloo']);
+  });
+
   test('List Clients send stuff to websockets', () => {
     const send = jest.fn();
     const ws = new SuperlumeWebSocket({

--- a/src/ListClient.test.ts
+++ b/src/ListClient.test.ts
@@ -47,6 +47,30 @@ describe('list clients', () => {
     expect(finishedAlpha.toArray()).toEqual(['"1"', '2', 3, '']);
   });
 
+  test('list clietns can map over items', () => {
+    const alpha = new InnerListClient(
+      checkpoint,
+      roomID,
+      docID,
+      listID,
+      ws,
+      'alpha'
+    );
+
+    const finished = alpha
+      .push(1)
+      .push({ x: 20, y: 30 })
+      .push(3)
+      .push('cats');
+
+    expect(finished.map((val, i, key) => [val, i, key])).toEqual([
+      [1, 0, '0:alpha'],
+      [{ x: 20, y: 30 }, 1, '1:alpha'],
+      [3, 2, '2:alpha'],
+      ['cats', 3, '3:alpha'],
+    ]);
+  });
+
   test('List Clients send stuff to websockets', () => {
     const send = jest.fn();
     const ws = new SuperlumeWebSocket({

--- a/src/ListClient.ts
+++ b/src/ListClient.ts
@@ -176,7 +176,7 @@ export class InnerListClient<T extends any> implements ObjectClient {
     return this.clone();
   }
 
-  push(val: T): InnerListClient<T> {
+  private pushOne(val: T): InnerListClient<T> {
     let lastID = this.rt.lastID();
     const escaped = escape(val as any);
 
@@ -188,6 +188,14 @@ export class InnerListClient<T extends any> implements ObjectClient {
     this.sendCmd(['lins', this.docID, this.id, lastID, itemID, escaped]);
 
     return this.clone();
+  }
+
+  push(...args: T[]): InnerListClient<T> {
+    let self;
+    for (let arg of args) {
+      self = this.pushOne(arg);
+    }
+    return self as InnerListClient<T>;
   }
 
   map<T extends any>(fn: (val: T, index: number, key: string) => T[]): T[] {

--- a/src/ListClient.ts
+++ b/src/ListClient.ts
@@ -190,6 +190,12 @@ export class InnerListClient<T extends any> implements ObjectClient {
     return this.clone();
   }
 
+  map<T extends any>(fn: (val: T, index: number, key: string) => T[]): T[] {
+    return this.rt
+      .postOrderTraverse()
+      .map((m, i) => fn(unescape(m.value) as T, i, m.id)) as Array<T>;
+  }
+
   toArray(): T[] {
     return this.rt.toArray().map(m => unescape(m)) as any[];
   }

--- a/src/MapClient.test.ts
+++ b/src/MapClient.test.ts
@@ -61,6 +61,7 @@ describe('InnerMapClient', () => {
 
     expect(val).toEqual({
       dogs: 'good',
+      name: 'alice',
       snakes: 'snakey',
     });
   });

--- a/src/MapClient.test.ts
+++ b/src/MapClient.test.ts
@@ -52,4 +52,16 @@ describe('InnerMapClient', () => {
     map.dangerouslyUpdateClientDirectly(['mdel', 'doc', 'map', 'cats']);
     expect(map.get('cats')).toBeFalsy();
   });
+
+  test('interprets mput', () => {
+    const val = map
+      .set('dogs', 'good')
+      .set('snakes', 'snakey')
+      .toObject();
+
+    expect(val).toEqual({
+      dogs: 'good',
+      snakes: 'snakey',
+    });
+  });
 });

--- a/src/MapClient.ts
+++ b/src/MapClient.ts
@@ -103,6 +103,14 @@ export class InnerMapClient<T extends any> implements ObjectClient {
     return this.clone();
   }
 
+  toObject(): { [key: string]: T } {
+    const obj = {} as { [key: string]: T };
+    for (let key of this.keys) {
+      obj[key] = this.get(key);
+    }
+    return obj;
+  }
+
   delete(key: string): InnerMapClient<T> {
     // local
     delete this.store[key];

--- a/src/ReverseTree.ts
+++ b/src/ReverseTree.ts
@@ -190,36 +190,39 @@ export default class ReverseTree {
     return right(root).id;
   }
 
-  toArray(): Array<any> {
+  postOrderTraverse() {
     this.sortLog();
 
     // -- Convert the log into a regular tree
     const root = this.toTree();
 
     // -- Do a depth-first traversal to get the result
-    function postorder(t: Tree): string[] {
+    function postorder(t: Tree): Tree[] {
       if (!t.children || t.children.length === 0) {
         return [];
       }
 
-      let vals: string[] = [];
+      let children: Tree[] = [];
       for (let child of t.children) {
-        let value = child.value;
         if (typeof child.value !== 'string') {
           // Skip tombstones
           if (child.value.t === '') {
-            vals = vals.concat([...postorder(child)]);
+            children = children.concat([...postorder(child)]);
             continue;
           }
           throw new Error('Unimplemented');
         }
 
-        vals = vals.concat([value, ...postorder(child)]);
+        children = children.concat([child, ...postorder(child)]);
       }
 
-      return vals;
+      return children;
     }
 
     return postorder(root);
+  }
+
+  toArray(): Array<any> {
+    return this.postOrderTraverse().map(c => c.value);
   }
 }

--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -26,11 +26,11 @@ type ListenerBundle = Array<Listener>;
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 export type MapClient<T> = Omit<
   InnerMapClient<T>,
-  'dangerouslyUpdateClientDirectly'
+  'dangerouslyUpdateClientDirectly' | 'id'
 >;
 export type ListClient<T> = Omit<
   InnerListClient<T>,
-  'dangerouslyUpdateClientDirectly'
+  'dangerouslyUpdateClientDirectly' | 'id'
 >;
 export type PresenceClient = Omit<
   InnerPresenceClient,

--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -110,7 +110,7 @@ export class RoomClient {
     return this.actor;
   }
 
-  list<T extends any>(name: string): InnerListClient<T> {
+  list<T extends any>(name: string): ListClient<T> {
     if (this.listClients[name]) {
       return this.listClients[name];
     }
@@ -143,7 +143,7 @@ export class RoomClient {
     return l;
   }
 
-  map<T extends any>(name: string): InnerMapClient<T> {
+  map<T extends any>(name: string): MapClient<T> {
     if (this.mapClients[name]) {
       return this.mapClients[name];
     }
@@ -168,7 +168,7 @@ export class RoomClient {
     return m;
   }
 
-  presence(): InnerPresenceClient {
+  presence(): PresenceClient {
     if (this.InnerPresenceClient) {
       return this.InnerPresenceClient;
     }


### PR DESCRIPTION
# Overview

This PR adds some helpers to current Room Service objects.

## `.toObject()`

Just like `.toArray()` there's now a `.toObject()` for Maps.

```js
map.toObject() 
```

## Typing fix for dangerouslyUpdateClientDirectly & id

TypeScript should now treat `dangerouslyUpdateClientDirectly` and `id` as private, so it shouldn't show up in autocomplete (in typescript or elsewhere). 

This doesn't happen anymore:
<img width="452" alt="Screen Shot 2020-10-16 at 2 20 11 PM" src="https://user-images.githubusercontent.com/5942769/96309723-b9c59700-0fba-11eb-8045-733dcbf2e8cb.png">

## Add .map() function

A lot of folks have been doing stuff like this:
```js
list.toArray().map(x => <div>{x}</div>)
```

So to help make this cleaner, you can now do a map function directly:
```js
list.map(x => <div>{x}</div>)
```

## Let .push() take varags

`list.push()` now works like the built-in javascript `.push` function: it supports var args.

```tsx
list.push(1, 2, "boogaloo") // this works now
```