### PR TITLE
Remove terrorist signifier

### DIFF
--- a/src/ListClient.test.ts
+++ b/src/ListClient.test.ts
@@ -81,8 +81,8 @@ describe('list clients', () => {
       'alpha'
     );
 
-    const finished = alpha.push(1, 2, 'boogaloo');
-    expect(finished.toArray()).toEqual([1, 2, 'boogaloo']);
+    const finished = alpha.push(1, 2, 'foo');
+    expect(finished.toArray()).toEqual([1, 2, 'foo']);
   });
 
   test('List Clients send stuff to websockets', () => {


### PR DESCRIPTION
"Boogaloo" has recently become [a rallying cry](https://en.wikipedia.org/wiki/Boogaloo_movement) for terrorists (ie: the folks that tried to kidnap the Michigan Governor). For a long time it's been one of my "foobar" words for tests, but I'd rather not throw them any accidental support. 