### PR TITLE
update internal clients independent of subscribed callbacks

### DIFF
--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -70,7 +70,6 @@ export class RoomClient {
     this.checkpoint = params.checkpoint;
     this.InnerPresenceClient = undefined;
 
-
     this.ws.bind('doc:fwd', body => {
       if (body.room !== this.roomID) return;
       if (!body.args || body.args.length < 3) {

--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -230,7 +230,7 @@ export class RoomClient {
         return;
       }
       // Ignore out of order version stamps
-      if (isOlderVS(body.vs, this.vs)) return;
+      if (isOlderVS(body.vs, this.checkpoint.vs)) return;
 
       // Ignore validated commands
       if (body.from === this.actor) return;

--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -88,12 +88,12 @@ export class RoomClient {
 
       if (docID !== this.docID) return;
 
-      if (cmd in MAP_CMDS) {
+      if (MAP_CMDS.includes(cmd)) {
         this.dispatchMapCmd(objID, body);
-      }
-
-      if (cmd in LIST_CMDS) {
+      } else if (LIST_CMDS.includes(cmd)) {
         this.dispatchListCmd(objID, body);
+      } else {
+        console.warn("Unhandled Room Service doc:fwd command: " + cmd + ". Consider updating the Room Service client.");
       }
 
     });
@@ -124,7 +124,7 @@ export class RoomClient {
         this.checkpoint.maps[objID] || {},
         this.roomID,
         this.docID,
-        name,
+        objID,
         this.ws
       );
       this.mapClients[objID] = m;
@@ -133,7 +133,7 @@ export class RoomClient {
     const client = this.mapClients[objID];
     const updatedClient = client.dangerouslyUpdateClientDirectly(body.args);
 
-    for (const cb of this.mapCallbacksByObjID[objID]){
+    for (const cb of (this.mapCallbacksByObjID[objID] || [])){
       cb(updatedClient, body.from);
     }
   }
@@ -144,7 +144,7 @@ export class RoomClient {
         this.checkpoint,
         this.roomID,
         this.docID,
-        name,
+        objID,
         this.ws,
         this.actor
       );
@@ -154,7 +154,7 @@ export class RoomClient {
     const client = this.listClients[objID];
     const updatedClient = client.dangerouslyUpdateClientDirectly(body.args);
 
-    for (const cb of this.listCallbacksByObjID[objID]){
+    for (const cb of (this.listCallbacksByObjID[objID] || [])){
       cb(updatedClient, body.from);
     }
   }

--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -2,7 +2,6 @@ import SuperlumeWebSocket from './ws';
 import {
   WebSocketLikeConnection,
   DocumentCheckpoint,
-  ObjectClient,
   AuthStrategy,
   Prop,
 } from './types';
@@ -12,7 +11,7 @@ import { InnerMapClient } from './MapClient';
 import { InnerPresenceClient } from './PresenceClient';
 import invariant from 'tiny-invariant';
 import { isOlderVS } from './versionstamp';
-import { WebSocketDocCmdMessage, WebSocketDocFwdMessage, WebSocketPresenceFwdMessage, WebSocketServerMessage } from 'wsMessages';
+import { WebSocketDocFwdMessage, WebSocketPresenceFwdMessage, WebSocketServerMessage } from 'wsMessages';
 
 const WEBSOCKET_TIMEOUT = 1000 * 2;
 
@@ -22,7 +21,6 @@ type Listener = {
   fn: (args: any) => void;
 };
 
-type Cb = (body: any) => void;
 
 const MAP_CMDS = ['mcreate', 'mput', 'mputref', 'mdel'];
 const LIST_CMDS = ['lcreate', 'lins', 'linsref', 'lput', 'lputref', 'ldel'];
@@ -45,7 +43,6 @@ export type PresenceClient = Omit<
 
 export class RoomClient {
   private ws: SuperlumeWebSocket;
-  private vs: string;
   private token: string;
   private roomID: string;
   private docID: string;
@@ -71,7 +68,6 @@ export class RoomClient {
     this.docID = params.checkpoint.id;
     this.actor = params.actor;
     this.checkpoint = params.checkpoint;
-    this.vs = this.checkpoint.vs;
     this.InnerPresenceClient = undefined;
 
 
@@ -372,14 +368,14 @@ export class RoomClient {
     if (obj instanceof InnerMapClient) {
       const client = obj as InnerMapClient<any>;
       objID = client.id;
-      this.mapCallbacksByObjID[objID] ||= [];
+      this.mapCallbacksByObjID[objID] = this.mapCallbacksByObjID[objID] || [];
       this.mapCallbacksByObjID[objID].push(cb);
     }
 
     if (obj instanceof InnerListClient) {
       const client = obj as InnerListClient<any>;
       objID = client.id;
-      this.listCallbacksByObjID[objID] ||= [];
+      this.listCallbacksByObjID[objID] = this.listCallbacksByObjID[objID] || [];
       this.listCallbacksByObjID[objID].push(cb);
     }
 
@@ -408,7 +404,7 @@ export class RoomClient {
         }
       };
 
-      this.presenceCallbacksByKey[key] ||= [];
+      this.presenceCallbacksByKey[key] = this.presenceCallbacksByKey[key] || [];
       this.presenceCallbacksByKey[key].push(cb);
 
     return [


### PR DESCRIPTION
## Problem
The client currently only maintains state for maps/lists that are locally subscribed to by the developer. Updates to maps and lists that are not currently subscribed to are dropped, leaving the client with incomplete state if it hasn't explicitly subscribed to every map/list.

## Solution
Process updates for all maps and lists regardless of subscription. Decouple websocket event-handling from client callback dispatching.

The shape this PR took is mostly moving the old client update logic into handlers that are always setup (on RoomClient construction), then adding minimal callback logic to the client to manage developer-requested subscriptions.