### PR TITLE
Refactor client inputs

### DIFF
--- a/src/ListClient.test.ts
+++ b/src/ListClient.test.ts
@@ -29,14 +29,14 @@ describe('list clients', () => {
   });
 
   test("List clients don't include extra quotes", () => {
-    const alpha = new InnerListClient(
+    const alpha = new InnerListClient({
       checkpoint,
       roomID,
       docID,
       listID,
       ws,
-      'alpha'
-    );
+      actor: 'alpha',
+    });
 
     const finishedAlpha = alpha
       .push('"1"')
@@ -48,14 +48,14 @@ describe('list clients', () => {
   });
 
   test('list clients can map over items', () => {
-    const alpha = new InnerListClient(
+    const alpha = new InnerListClient({
       checkpoint,
       roomID,
       docID,
       listID,
       ws,
-      'alpha'
-    );
+      actor: 'alpha',
+    });
 
     const finished = alpha
       .push(1)
@@ -72,14 +72,14 @@ describe('list clients', () => {
   });
 
   test('list.push supports varags', () => {
-    const alpha = new InnerListClient(
+    const alpha = new InnerListClient({
       checkpoint,
       roomID,
       docID,
       listID,
       ws,
-      'alpha'
-    );
+      actor: 'alpha',
+    });
 
     const finished = alpha.push(1, 2, 'foo');
     expect(finished.toArray()).toEqual([1, 2, 'foo']);
@@ -93,14 +93,14 @@ describe('list clients', () => {
       readyState: WebSocket.OPEN,
     });
 
-    const alpha = new InnerListClient(
-      checkpoint,
-      roomID,
+    const alpha = new InnerListClient({
+      checkpoint: checkpoint,
+      roomID: roomID,
       docID,
       listID,
       ws,
-      'alpha'
-    );
+      actor: 'alpha',
+    });
     alpha.push('cats');
 
     const msg = JSON.parse(send.mock.calls[0][0]) as any;
@@ -121,14 +121,14 @@ describe('list clients', () => {
       send,
     });
 
-    let alpha = new InnerListClient(
+    let alpha = new InnerListClient({
       checkpoint,
       roomID,
       docID,
       listID,
       ws,
-      'alpha'
-    );
+      actor: 'alpha',
+    });
     alpha = alpha.push('cats');
     alpha = alpha.dangerouslyUpdateClientDirectly([
       'lins',
@@ -180,14 +180,14 @@ describe('list clients', () => {
       send,
     });
 
-    let alpha = new InnerListClient(
-      fixture.body,
+    let alpha = new InnerListClient({
+      checkpoint: fixture.body,
       roomID,
-      fixture.body.id,
-      'todo',
+      docID: fixture.body.id,
+      listID: 'todo',
       ws,
-      'gst_b355e9c9-f1d3-4233-a6c5-e75e1cd0e52c'
-    );
+      actor: 'gst_b355e9c9-f1d3-4233-a6c5-e75e1cd0e52c',
+    });
 
     // Sanity check our import is correct
     expect(alpha.toArray()).toEqual(['okay', 'alright cool', 'left', 'right']);

--- a/src/ListClient.ts
+++ b/src/ListClient.ts
@@ -16,34 +16,34 @@ export class InnerListClient<T extends any> implements ObjectClient {
 
   id: string;
 
-  constructor(
-    checkpoint: DocumentCheckpoint,
-    roomID: string,
-    docID: string,
-    listID: string,
-    ws: SuperlumeWebSocket,
-    actor: string
-  ) {
-    this.roomID = roomID;
-    this.docID = docID;
-    this.id = listID;
-    this.ws = ws;
-    this.rt = new ReverseTree(actor);
+  constructor(props: {
+    checkpoint: DocumentCheckpoint;
+    roomID: string;
+    docID: string;
+    listID: string;
+    ws: SuperlumeWebSocket;
+    actor: string;
+  }) {
+    this.roomID = props.roomID;
+    this.docID = props.docID;
+    this.id = props.listID;
+    this.ws = props.ws;
+    this.rt = new ReverseTree(props.actor);
 
     invariant(
-      checkpoint.lists[listID],
-      `Unknown listid '${listID}' in checkpoint.`
+      props.checkpoint.lists[props.listID],
+      `Unknown listid '${props.listID}' in checkpoint.`
     );
 
-    this.rt.import(checkpoint, listID);
-    const list = checkpoint.lists[listID];
+    this.rt.import(props.checkpoint, props.listID);
+    const list = props.checkpoint.lists[props.listID];
     const ids = list.ids || [];
     for (let i = 0; i < ids.length; i++) {
-      const val = checkpoint.lists[listID].values[i];
+      const val = props.checkpoint.lists[props.listID].values[i];
       if (typeof val === 'object' && val['t'] === '') {
         continue; // skip tombstones
       }
-      this.itemIDs.push(unescapeID(checkpoint, ids[i]));
+      this.itemIDs.push(unescapeID(props.checkpoint, ids[i]));
     }
   }
 

--- a/src/MapClient.test.ts
+++ b/src/MapClient.test.ts
@@ -10,7 +10,13 @@ describe('InnerMapClient', () => {
     readyState: WebSocket.OPEN,
   });
 
-  const map = new InnerMapClient({}, 'room', 'doc', 'map', ws);
+  const map = new InnerMapClient({
+    checkpoint: {},
+    roomID: 'room',
+    docID: 'doc',
+    mapID: 'map',
+    ws,
+  });
 
   test('has the correct id', () => {
     expect(map.id).toEqual('map');

--- a/src/MapClient.ts
+++ b/src/MapClient.ts
@@ -10,22 +10,22 @@ export class InnerMapClient<T extends any> implements ObjectClient {
 
   id: string;
 
-  constructor(
-    checkpoint: MapCheckpoint,
-    roomID: string,
-    docID: string,
-    mapID: string,
-    ws: SuperlumeWebSocket
-  ) {
-    this.roomID = roomID;
-    this.docID = docID;
-    this.id = mapID;
-    this.ws = ws;
+  constructor(props: {
+    checkpoint: MapCheckpoint;
+    roomID: string;
+    docID: string;
+    mapID: string;
+    ws: SuperlumeWebSocket;
+  }) {
+    this.roomID = props.roomID;
+    this.docID = props.docID;
+    this.id = props.mapID;
+    this.ws = props.ws;
     this.store = {};
 
     // import
-    for (let k in checkpoint) {
-      const val = checkpoint[k];
+    for (let k in props.checkpoint) {
+      const val = props.checkpoint[k];
       if (typeof val === 'string') {
         this.store[k] = unescape(val);
       }

--- a/src/PresenceClient.ts
+++ b/src/PresenceClient.ts
@@ -16,16 +16,16 @@ export class InnerPresenceClient {
   private cache: { [key: string]: PresenceCheckpoint<any> };
   private sendPres: (key: string, args: any) => any;
 
-  constructor(
-    roomID: string,
-    ws: SuperlumeWebSocket,
-    actor: string,
-    token: string
-  ) {
-    this.roomID = roomID;
-    this.ws = ws;
-    this.actor = actor;
-    this.token = token;
+  constructor(props: {
+    roomID: string;
+    ws: SuperlumeWebSocket;
+    actor: string;
+    token: string;
+  }) {
+    this.roomID = props.roomID;
+    this.ws = props.ws;
+    this.actor = props.actor;
+    this.token = props.token;
     this.cache = {};
 
     const sendPres = (_: string, args: any) => {

--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -129,13 +129,13 @@ export class RoomClient {
     body: Prop<WebSocketDocFwdMessage, 'body'>
   ) {
     if (!this.mapClients[objID]) {
-      const m = new InnerMapClient<any>(
-        this.checkpoint.maps[objID] || {},
-        this.roomID,
-        this.docID,
-        objID,
-        this.ws
-      );
+      const m = new InnerMapClient<any>({
+        checkpoint: this.checkpoint.maps[objID] || {},
+        roomID: this.roomID,
+        docID: this.docID,
+        mapID: objID,
+        ws: this.ws,
+      });
       this.mapClients[objID] = m;
     }
 
@@ -152,14 +152,14 @@ export class RoomClient {
     body: Prop<WebSocketDocFwdMessage, 'body'>
   ) {
     if (!this.listClients[objID]) {
-      const l = new InnerListClient<any>(
-        this.checkpoint,
-        this.roomID,
-        this.docID,
-        objID,
-        this.ws,
-        this.actor
-      );
+      const l = new InnerListClient<any>({
+        checkpoint: this.checkpoint,
+        roomID: this.roomID,
+        docID: this.docID,
+        listID: objID,
+        ws: this.ws,
+        actor: this.actor,
+      });
       this.listClients[objID] = l;
     }
 
@@ -277,14 +277,14 @@ export class RoomClient {
       };
     }
 
-    const l = new InnerListClient<T>(
-      this.checkpoint,
-      this.roomID,
-      this.docID,
-      name,
-      this.ws,
-      this.actor
-    );
+    const l = new InnerListClient<T>({
+      checkpoint: this.checkpoint,
+      roomID: this.roomID,
+      docID: this.docID,
+      listID: name,
+      ws: this.ws,
+      actor: this.actor,
+    });
     this.listClients[name] = l;
 
     return l;
@@ -303,13 +303,13 @@ export class RoomClient {
       });
     }
 
-    const m = new InnerMapClient<T>(
-      this.checkpoint.maps[name] || {},
-      this.roomID,
-      this.docID,
-      name,
-      this.ws
-    );
+    const m = new InnerMapClient<T>({
+      checkpoint: this.checkpoint.maps[name] || {},
+      roomID: this.roomID,
+      docID: this.docID,
+      mapID: name,
+      ws: this.ws,
+    });
     this.mapClients[name] = m;
 
     return m;
@@ -319,12 +319,12 @@ export class RoomClient {
     if (this.InnerPresenceClient) {
       return this.InnerPresenceClient;
     }
-    const p = new InnerPresenceClient(
-      this.roomID,
-      this.ws,
-      this.actor,
-      this.token
-    );
+    const p = new InnerPresenceClient({
+      roomID: this.roomID,
+      ws: this.ws,
+      actor: this.actor,
+      token: this.token,
+    });
     try {
       this.InnerPresenceClient = p;
     } catch (err) {


### PR DESCRIPTION
# Overview

All this PR does is refactor the constructors of the `ListClient`, `MapClient`, and `PresenceClient` to take an object instead of several parameters, and run a formatter on a file.

```
// before
MapClient(x, y, z, blah, blahh)

// After
MapClient({
  x,
  y,
  blah,
  blahhh
})
```

I'm doing this as part of the mutations-anywhere-trigger-all-the-subscribes thing for Omi & Julius, and they were getting kind ugly :( 

## Why tho

This makes it easier to add optional stuffs without having to refactor everything in the future. It's probably what I should have done in the first place 