### PR TITLE
fix list traversal order

### DIFF
--- a/src/ListClient.ts
+++ b/src/ListClient.ts
@@ -80,7 +80,7 @@ export class InnerListClient<T extends any> implements ObjectClient {
         const insItemID = cmd[4];
         const insValue = cmd[5];
         this.itemIDs.splice(
-          this.itemIDs.findIndex((f) => f === insAfter) + 1,
+          this.itemIDs.findIndex(f => f === insAfter) + 1,
           0,
           insItemID
         );
@@ -95,7 +95,7 @@ export class InnerListClient<T extends any> implements ObjectClient {
         const delItemID = cmd[3];
         this.rt.delete(delItemID);
         this.itemIDs.splice(
-          this.itemIDs.findIndex((f) => f === delItemID),
+          this.itemIDs.findIndex(f => f === delItemID),
           1
         );
         break;
@@ -200,11 +200,13 @@ export class InnerListClient<T extends any> implements ObjectClient {
 
   map<T extends any>(fn: (val: T, index: number, key: string) => T[]): T[] {
     return this.rt
-      .postOrderTraverse()
-      .map((m, i) => fn(unescape(m.value) as T, i, m.id)) as Array<T>;
+      .preOrderTraverse()
+      .map((idValue, i) =>
+        fn(unescape(idValue.value) as T, i, idValue.id)
+      ) as Array<T>;
   }
 
   toArray(): T[] {
-    return this.rt.toArray().map((m) => unescape(m)) as any[];
+    return this.rt.toArray().map(m => unescape(m)) as any[];
   }
 }

--- a/src/ReverseTree.test.ts
+++ b/src/ReverseTree.test.ts
@@ -30,9 +30,9 @@ test('reverse tree skips unreceived dependencies', () => {
 test('reverse tree can insert lots of items', () => {
   const rt = new ReverseTree('me');
 
-  const result = [];
+  const result: string[] = [];
   for (let i = 0; i < 20; i++) {
-    result.push(`donut #${i}`);
+    result.splice(0, 0, `donut #${i}`);
     rt.insert('root', `donut #${i}`);
   }
   expect(rt.toArray()).toEqual(result);
@@ -41,14 +41,14 @@ test('reverse tree can insert lots of items', () => {
 test('reverse tree always returns the last id', () => {
   const rt = new ReverseTree('me');
 
-  const result = [];
   for (let i = 0; i < 20; i++) {
-    result.push(`${i}`);
     rt.insert('root', `${i}`);
   }
 
   const arr = rt.toArray();
-  expect(rt.nodes[`19:me`].value).toEqual(arr[arr.length - 1]);
+  //  later inserts after the root come first, so the last node in the array is
+  //  the first that was inserted
+  expect(rt.nodes[`0:me`].value).toEqual(arr[arr.length - 1]);
 });
 
 test('reverse tree doesnt interweave', () => {

--- a/src/ReverseTree.ts
+++ b/src/ReverseTree.ts
@@ -159,7 +159,6 @@ export default class ReverseTree {
         return node;
       }
 
-      //
       return right(t, children[children.length - 1]);
     }
 

--- a/src/ReverseTree.ts
+++ b/src/ReverseTree.ts
@@ -170,8 +170,18 @@ export default class ReverseTree {
     // -- Convert the log into a regular tree
     const tree = this.toTree();
 
+    const seenNodes = new Set<string>();
+
     // -- Do a depth-first traversal to get the result
     function preOrder(t: Tree, node: string): IdValue[] {
+      if (seenNodes.has(node)) {
+        console.warn(
+          'RoomService list cycle detected. Consider updating @roomservice/browser.'
+        );
+        return [];
+      }
+      seenNodes.add(node);
+
       let result: IdValue[] = [];
       const value = t.valueById.get(node);
 


### PR DESCRIPTION
- fix naming postOrder -> preOrder (outputs current node first, which is
    what we were already doing)
- sort by _descending_ logical ts instead of ascending
    this fixes the ordering when multiple nodes are inserted
    sequentially after the same node
- sort children arrays instead of the whole log
    we only need a local ordering, and this prevents having to do an
    nlogn operation on the whole log