### PR TITLE
Add ctx to auth function

### DIFF
--- a/src/ListClient.test.ts
+++ b/src/ListClient.test.ts
@@ -38,11 +38,7 @@ describe('list clients', () => {
       actor: 'alpha',
     });
 
-    const finishedAlpha = alpha
-      .push('"1"')
-      .push('2')
-      .push(3)
-      .push('');
+    const finishedAlpha = alpha.push('"1"').push('2').push(3).push('');
 
     expect(finishedAlpha.toArray()).toEqual(['"1"', '2', 3, '']);
   });
@@ -57,11 +53,7 @@ describe('list clients', () => {
       actor: 'alpha',
     });
 
-    const finished = alpha
-      .push(1)
-      .push({ x: 20, y: 30 })
-      .push(3)
-      .push('cats');
+    const finished = alpha.push(1).push({ x: 20, y: 30 }).push(3).push('cats');
 
     expect(finished.map((val, i, key) => [val, i, key])).toEqual([
       [1, 0, '0:alpha'],
@@ -214,10 +206,7 @@ describe('list clients', () => {
       actor: 'me',
     });
 
-    const finished = l
-      .insertAt(0, 'c')
-      .insertAt(0, 'a')
-      .insertAt(1, 'b');
+    const finished = l.insertAt(0, 'c').insertAt(0, 'a').insertAt(1, 'b');
 
     expect(finished.toArray()).toEqual(['a', 'b', 'c']);
   });

--- a/src/ListClient.ts
+++ b/src/ListClient.ts
@@ -80,7 +80,7 @@ export class InnerListClient<T extends any> implements ObjectClient {
         const insItemID = cmd[4];
         const insValue = cmd[5];
         this.itemIDs.splice(
-          this.itemIDs.findIndex(f => f === insAfter) + 1,
+          this.itemIDs.findIndex((f) => f === insAfter) + 1,
           0,
           insItemID
         );
@@ -95,7 +95,7 @@ export class InnerListClient<T extends any> implements ObjectClient {
         const delItemID = cmd[3];
         this.rt.delete(delItemID);
         this.itemIDs.splice(
-          this.itemIDs.findIndex(f => f === delItemID),
+          this.itemIDs.findIndex((f) => f === delItemID),
           1
         );
         break;
@@ -220,6 +220,6 @@ export class InnerListClient<T extends any> implements ObjectClient {
   }
 
   toArray(): T[] {
-    return this.rt.toArray().map(m => unescape(m)) as any[];
+    return this.rt.toArray().map((m) => unescape(m)) as any[];
   }
 }

--- a/src/ReverseTree.ts
+++ b/src/ReverseTree.ts
@@ -125,7 +125,7 @@ export default class ReverseTree {
       valueById.set(node.id, node.value);
     }
 
-    childrenById.forEach(children => {
+    childrenById.forEach((children) => {
       //  sort by logical timestamp descending so that latest inserts appear first
       children.sort((a, b) => {
         const [leftCount, leftActor] = a.split(':');
@@ -210,6 +210,6 @@ export default class ReverseTree {
   }
 
   toArray(): Array<any> {
-    return this.preOrderTraverse().map(idValue => idValue.value);
+    return this.preOrderTraverse().map((idValue) => idValue.value);
   }
 }

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -66,14 +66,18 @@ export interface LocalSession {
   roomID: string;
 }
 
-export async function fetchSession(
-  strategy: AuthStrategy,
+export async function fetchSession<T extends object>(
+  strategy: AuthStrategy<T>,
+  ctx: T,
   room: string,
   document: string
 ): Promise<LocalSession> {
   // A user defined function
   if (typeof strategy === 'function') {
-    const result = await strategy(room);
+    const result = await strategy({
+      room,
+      ctx,
+    });
     if (!result.user) {
       throw new Error(`The auth function must return a 'user' key.`);
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,5 +110,8 @@ export interface AuthResponse {
   resources: Resource[];
 }
 
-export type AuthFunction = (room: string) => Promise<AuthResponse>;
-export type AuthStrategy = string | AuthFunction;
+export type AuthFunction<T extends object> = (params: {
+  room: string;
+  ctx: T;
+}) => Promise<AuthResponse>;
+export type AuthStrategy<T extends object> = string | AuthFunction<T>;


### PR DESCRIPTION
# Overview

This PR stabilizes an unstable API (read: undocumented) that lets people pass in a custom auth function into the room service client:

```js
new RoomService({
  auth: () => {
    // ...
  }
})
```

## Before
Previously, this auth function would pass you the `room` as a string:
```js
(room) => {
  console.log(room) // "foobar"
}
```

## After

Now, the auth function passes you an object with the room inside it:
```js
(params) => {
  console.log(params.room) // "foobar"
}
```

This object also includes a `ctx` property that the user can pass in from the `RoomService` constructor that allows any context from the user if they'd like:

```
new RoomService({
  auth: myAuthFn,
  ctx: {
    user: "my-user-details",
    project: "some-cool-project"
  } 
})
```