### PR TITLE
v3: JSON subscriptions & Presence Standardization

### DIFF
--- a/errors/infinite-loop.md
+++ b/errors/infinite-loop.md
@@ -10,24 +10,20 @@ For example, this code throws an "Infinite loop detected" error:
 
 ```tsx
 // This is causes an infinite loop
-room.subscribe(map, (nextMap) => {
-  nextMap.set('name', 'joe');
+room.subscribe(map, (json) => {
+  map.set('name', 'joe');
 });
 ```
 
 ## How to fix
 
-Ensure you're not making updates inside of subscription functions. Instead, store the state somewhere else, and then update it.
-
-For example:
+Ensure you're not making updates inside of subscription functions. For example:
 
 ```tsx
-// This does not cause an infinite loop
-let state = map;
-
-room.subscribe(map, (nextMap) => {
-  state = nextMap;
+room.subscribe(map, (json) => {
+  // ...
 });
 
+// This does not cause an infinite loop
 nextMap.set('name', 'joe');
 ```

--- a/example/pages/lists.tsx
+++ b/example/pages/lists.tsx
@@ -4,8 +4,9 @@ import { useEffect, useState } from 'react';
 function useList(
   roomName: string,
   listName: string
-): [ListClient<any>, (l: ListClient<any>) => void] {
+): [Array<any>, ListClient<any>] {
   const [list, setList] = useState<ListClient<any>>();
+  const [json, setJSON] = useState([]);
 
   useEffect(() => {
     async function load() {
@@ -13,31 +14,32 @@ function useList(
         auth: '/api/hello',
       });
       const room = await client.room(roomName);
-      const l = await room.list(listName);
+      const l = room.list(listName);
       setList(l);
+      setJSON(l.toArray());
 
-      room.subscribe(l, (li) => {
-        setList(li);
+      room.subscribe(l, (arr) => {
+        setJSON(arr);
       });
     }
     load();
   }, []);
 
-  return [list, setList];
+  return [json, list];
 }
 
 export default function List() {
-  const [list, setList] = useList('lists', 'todos');
+  const [value, list] = useList('lists', 'todos');
   const [text, setText] = useState('');
 
   function onCheckOff(i: number) {
     if (!list) return;
-    setList(list.delete(i));
+    list.delete(i);
   }
 
   function onEnterPress() {
     if (!list) return;
-    setList(list.push(text));
+    list.push(text);
     setText('');
   }
 
@@ -54,18 +56,17 @@ export default function List() {
           }
         }}
       />
-      {list &&
-        list.toArray().map((l, i) => (
-          <p
-            className="todo"
-            key={JSON.stringify(l) + '-' + i}
-            onClick={() => onCheckOff(i)}
-          >
-            {l.object || l}
-            {'-'}
-            {i}
-          </p>
-        ))}
+      {value.map((l, i) => (
+        <p
+          className="todo"
+          key={JSON.stringify(l) + '-' + i}
+          onClick={() => onCheckOff(i)}
+        >
+          {l.object || l}
+          {'-'}
+          {i}
+        </p>
+      ))}
       <style jsx>{`
         .container {
           margin: 0 auto;

--- a/example/pages/lists.tsx
+++ b/example/pages/lists.tsx
@@ -29,7 +29,7 @@ function useList(
 }
 
 export default function List() {
-  const [value, list] = useList('lists', 'todos');
+  const [value, list] = useList('lists17', 'todos');
   const [text, setText] = useState('');
 
   function onCheckOff(i: number) {

--- a/example/pages/local-subs.tsx
+++ b/example/pages/local-subs.tsx
@@ -31,22 +31,22 @@ function Input(props) {
 }
 
 function ViewPort(props) {
-  const [map, setMap] = useState() as any;
+  const [state, setState] = useState({ name: '' });
   const room = useRoom(props.roomName);
   const counts = useRef(0);
 
   useEffect(() => {
     if (!room) return;
     const map = room.map(props.mapName);
-    setMap(map);
-    room.subscribe(map, (nextMap) => {
+    setState(map.toObject());
+    room.subscribe(map, (json) => {
       counts.current++;
       console.log(counts.current);
-      setMap(nextMap);
+      setState(json);
     });
   }, [room]);
 
-  return <div>{map && map.get('name')}</div>;
+  return <div>{state.name || ''}</div>;
 }
 
 export default function Home() {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.5-4",
+  "version": "3.0.0-0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "ts-jest": "^24.2.0",
     "tsdx": "^0.12.3",
     "tslib": "^1.11.1",
-    "typescript": "^3.8.3"
+    "typescript": "latest"
   },
   "dependencies": {
     "@roomservice/core": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.0-0",
+  "version": "3.0.0-1",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/ListClient.ts
+++ b/src/ListClient.ts
@@ -4,7 +4,7 @@ import invariant from 'tiny-invariant';
 import { LocalBus } from './localbus';
 import { ListInterpreter, ListMeta, ListStore } from '@roomservice/core';
 
-type ListObject = Array<any>;
+export type ListObject = Array<any>;
 
 export class InnerListClient<T extends ListObject> implements ObjectClient {
   private roomID: string;

--- a/src/ListClient.ts
+++ b/src/ListClient.ts
@@ -108,7 +108,7 @@ export class InnerListClient<T extends ListObject> implements ObjectClient {
   }
 
   insertAfter<K extends number>(index: K, val: T[K]): InnerListClient<T> {
-    return this.insertAt((index as number) + 1, val as any);
+    return this.insertAt((index as number) + 1, val);
   }
 
   insertAt<K extends number>(index: K, val: T[K]): InnerListClient<T> {
@@ -135,13 +135,13 @@ export class InnerListClient<T extends ListObject> implements ObjectClient {
     return this as InnerListClient<T>;
   }
 
-  map<K extends keyof T, V extends T[K]>(
-    fn: (val: V, index: K, key: string) => Array<T[K]>
+  map<K extends number>(
+    fn: (val: T[K], index: number, key: string) => Array<T[number]>
   ): Array<T[K]> {
-    return ListInterpreter.map(this.store, fn as any);
+    return ListInterpreter.map(this.store, fn);
   }
 
   toArray(): T[] {
-    return ListInterpreter.toArray(this.store);
+    return ListInterpreter.toArray<T[number]>(this.store);
   }
 }

--- a/src/ListClient.ts
+++ b/src/ListClient.ts
@@ -77,11 +77,11 @@ export class InnerListClient<T extends ListObject> implements ObjectClient {
     return this.clone();
   }
 
-  get<K extends keyof T>(index: K): T | undefined {
+  get<K extends number>(index: K): T[K] | undefined {
     return ListInterpreter.get<T>(this.store, index as any);
   }
 
-  set<K extends keyof T>(index: K, val: T[K]): InnerListClient<T> {
+  set<K extends number>(index: K, val: T[K]): InnerListClient<T> {
     const cmd = ListInterpreter.runSet(
       this.store,
       this.meta,
@@ -95,7 +95,7 @@ export class InnerListClient<T extends ListObject> implements ObjectClient {
     return this.clone();
   }
 
-  delete<K extends keyof T>(index: K): InnerListClient<T> {
+  delete<K extends number>(index: K): InnerListClient<T> {
     const cmd = ListInterpreter.runDelete(this.store, this.meta, index as any);
     if (!cmd) {
       return this.clone();
@@ -107,11 +107,11 @@ export class InnerListClient<T extends ListObject> implements ObjectClient {
     return this.clone();
   }
 
-  insertAfter<K extends keyof T>(index: K, val: T[K]): InnerListClient<T> {
+  insertAfter<K extends number>(index: K, val: T[K]): InnerListClient<T> {
     return this.insertAt((index as number) + 1, val as any);
   }
 
-  insertAt<K extends keyof T>(index: K, val: T[K]): InnerListClient<T> {
+  insertAt<K extends number>(index: K, val: T[K]): InnerListClient<T> {
     const cmd = ListInterpreter.runInsertAt(
       this.store,
       this.meta,
@@ -125,7 +125,7 @@ export class InnerListClient<T extends ListObject> implements ObjectClient {
     return this.clone();
   }
 
-  push<K extends keyof T>(...args: Array<T[K]>): InnerListClient<T> {
+  push<K extends number>(...args: Array<T[K]>): InnerListClient<T> {
     const cmds = ListInterpreter.runPush(this.store, this.meta, ...args);
 
     for (let cmd of cmds) {
@@ -135,10 +135,10 @@ export class InnerListClient<T extends ListObject> implements ObjectClient {
     return this as InnerListClient<T>;
   }
 
-  map<K extends keyof T>(
-    fn: (val: T[K], index: number, key: string) => Array<T[K]>
+  map<K extends keyof T, V extends T[K]>(
+    fn: (val: V, index: K, key: string) => Array<T[K]>
   ): Array<T[K]> {
-    return ListInterpreter.map(this.store, fn);
+    return ListInterpreter.map(this.store, fn as any);
   }
 
   toArray(): T[] {

--- a/src/ListClient.ts
+++ b/src/ListClient.ts
@@ -4,9 +4,7 @@ import invariant from 'tiny-invariant';
 import { LocalBus } from './localbus';
 import { ListInterpreter, ListMeta, ListStore } from '@roomservice/core';
 
-export type ListObject = Array<any>;
-
-export class InnerListClient<T extends ListObject> implements ObjectClient {
+export class InnerListClient<T extends any> implements ObjectClient {
   private roomID: string;
   private ws: SuperlumeWebSocket;
   private bus: LocalBus<any>;
@@ -77,11 +75,11 @@ export class InnerListClient<T extends ListObject> implements ObjectClient {
     return this.clone();
   }
 
-  get<K extends number>(index: K): T[K] | undefined {
+  get<K extends number>(index: K): T | undefined {
     return ListInterpreter.get<T>(this.store, index as any);
   }
 
-  set<K extends number>(index: K, val: T[K]): InnerListClient<T> {
+  set<K extends number>(index: K, val: T): InnerListClient<T> {
     const cmd = ListInterpreter.runSet(
       this.store,
       this.meta,
@@ -107,11 +105,11 @@ export class InnerListClient<T extends ListObject> implements ObjectClient {
     return this.clone();
   }
 
-  insertAfter<K extends number>(index: K, val: T[K]): InnerListClient<T> {
+  insertAfter<K extends number>(index: K, val: T): InnerListClient<T> {
     return this.insertAt((index as number) + 1, val as any);
   }
 
-  insertAt<K extends number>(index: K, val: T[K]): InnerListClient<T> {
+  insertAt<K extends number>(index: K, val: T): InnerListClient<T> {
     const cmd = ListInterpreter.runInsertAt(
       this.store,
       this.meta,
@@ -125,7 +123,7 @@ export class InnerListClient<T extends ListObject> implements ObjectClient {
     return this.clone();
   }
 
-  push<K extends number>(...args: Array<T[K]>): InnerListClient<T> {
+  push(...args: Array<T>): InnerListClient<T> {
     const cmds = ListInterpreter.runPush(this.store, this.meta, ...args);
 
     for (let cmd of cmds) {

--- a/src/ListClient.ts
+++ b/src/ListClient.ts
@@ -4,7 +4,9 @@ import invariant from 'tiny-invariant';
 import { LocalBus } from './localbus';
 import { ListInterpreter, ListMeta, ListStore } from '@roomservice/core';
 
-export class InnerListClient<T extends any> implements ObjectClient {
+export type ListObject = Array<any>;
+
+export class InnerListClient<T extends ListObject> implements ObjectClient {
   private roomID: string;
   private ws: SuperlumeWebSocket;
   private bus: LocalBus<any>;
@@ -75,11 +77,11 @@ export class InnerListClient<T extends any> implements ObjectClient {
     return this.clone();
   }
 
-  get<K extends number>(index: K): T | undefined {
+  get<K extends number>(index: K): T[K] | undefined {
     return ListInterpreter.get<T>(this.store, index as any);
   }
 
-  set<K extends number>(index: K, val: T): InnerListClient<T> {
+  set<K extends number>(index: K, val: T[K]): InnerListClient<T> {
     const cmd = ListInterpreter.runSet(
       this.store,
       this.meta,
@@ -105,11 +107,11 @@ export class InnerListClient<T extends any> implements ObjectClient {
     return this.clone();
   }
 
-  insertAfter<K extends number>(index: K, val: T): InnerListClient<T> {
+  insertAfter<K extends number>(index: K, val: T[K]): InnerListClient<T> {
     return this.insertAt((index as number) + 1, val as any);
   }
 
-  insertAt<K extends number>(index: K, val: T): InnerListClient<T> {
+  insertAt<K extends number>(index: K, val: T[K]): InnerListClient<T> {
     const cmd = ListInterpreter.runInsertAt(
       this.store,
       this.meta,
@@ -123,7 +125,7 @@ export class InnerListClient<T extends any> implements ObjectClient {
     return this.clone();
   }
 
-  push(...args: Array<T>): InnerListClient<T> {
+  push<K extends number>(...args: Array<T[K]>): InnerListClient<T> {
     const cmds = ListInterpreter.runPush(this.store, this.meta, ...args);
 
     for (let cmd of cmds) {

--- a/src/MapClient.ts
+++ b/src/MapClient.ts
@@ -8,7 +8,7 @@ import {
   DocumentCheckpoint,
 } from '@roomservice/core';
 
-type MapObject = { [key: string]: any };
+export type MapObject = { [key: string]: any };
 
 export class InnerMapClient<T extends MapObject> implements ObjectClient {
   private roomID: string;

--- a/src/MapClient.ts
+++ b/src/MapClient.ts
@@ -8,12 +8,14 @@ import {
   DocumentCheckpoint,
 } from '@roomservice/core';
 
-export class InnerMapClient<T extends any> implements ObjectClient {
+type MapObject = { [key: string]: any };
+
+export class InnerMapClient<T extends MapObject> implements ObjectClient {
   private roomID: string;
   private ws: SuperlumeWebSocket;
 
   private meta: MapMeta;
-  private store: MapStore<T>;
+  private store: MapStore<any>;
   private bus: LocalBus<any>;
   private actor: string;
 
@@ -75,12 +77,12 @@ export class InnerMapClient<T extends any> implements ObjectClient {
     return Object.keys(this.store);
   }
 
-  get(key: string): T {
-    return this.store[key] as T;
+  get<K extends keyof T>(key: K): T {
+    return this.store[key as any] as T;
   }
 
-  set(key: string, value: T): InnerMapClient<T> {
-    const cmd = MapInterpreter.runSet(this.store, this.meta, key, value);
+  set<K extends keyof T>(key: K, value: T[K]): InnerMapClient<T> {
+    const cmd = MapInterpreter.runSet(this.store, this.meta, key as any, value);
 
     // Remote
     this.sendCmd(cmd);
@@ -96,8 +98,8 @@ export class InnerMapClient<T extends any> implements ObjectClient {
     return obj;
   }
 
-  delete(key: string): InnerMapClient<T> {
-    const cmd = MapInterpreter.runDelete(this.store, this.meta, key);
+  delete<K extends keyof T>(key: K): InnerMapClient<T> {
+    const cmd = MapInterpreter.runDelete(this.store, this.meta, key as any);
 
     // remote
     this.sendCmd(cmd);

--- a/src/MapClient.ts
+++ b/src/MapClient.ts
@@ -77,8 +77,8 @@ export class InnerMapClient<T extends MapObject> implements ObjectClient {
     return Object.keys(this.store);
   }
 
-  get<K extends keyof T>(key: K): T {
-    return this.store[key as any] as T;
+  get<K extends keyof T>(key: K): T[K] {
+    return this.store[key as any] as T[K];
   }
 
   set<K extends keyof T>(key: K, value: T[K]): InnerMapClient<T> {
@@ -90,8 +90,8 @@ export class InnerMapClient<T extends MapObject> implements ObjectClient {
     return this.clone();
   }
 
-  toObject(): { [key: string]: T } {
-    const obj = {} as { [key: string]: T };
+  toObject(): T {
+    const obj = {} as any;
     for (let key of this.keys) {
       obj[key] = this.get(key);
     }

--- a/src/RoomClient.test.ts
+++ b/src/RoomClient.test.ts
@@ -59,31 +59,6 @@ test('RoomClient.connect() will send authenticate and connect messages', (done) 
   });
 });
 
-test('infinite loop bugs can be fixed with example', () => {
-  const conn = {
-    onmessage: (_?: MessageEvent) => {},
-    send: (_?: any) => {},
-    readyState: WebSocket.OPEN,
-  };
-  const client = new RoomClient({
-    actor: 'me',
-    checkpoint: cp,
-    roomID: 'room',
-    token: 'token',
-    conn: conn,
-  });
-
-  const m = client.map('mymap');
-  let state = m;
-  client.subscribe(m, (nextMap) => {
-    state = nextMap;
-  });
-  state.set('dogs', 'cats');
-  state.set('cats', 'dogs'); // Two loops are fine!
-
-  expect(state !== m).toBeTruthy();
-});
-
 test('we catch infinite loops', () => {
   function thisThrows() {
     const conn = {
@@ -99,8 +74,8 @@ test('we catch infinite loops', () => {
       conn: conn,
     });
     const m = client.map('mymap');
-    client.subscribe(m, (nextMap) => {
-      nextMap.set('I', 'cause an infinite loop');
+    client.subscribe(m, () => {
+      m.set('I', 'cause an infinite loop');
     });
 
     m.set('I', 'trigger the bad times');

--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -244,7 +244,10 @@ export class RoomClient {
   private createListLocally<T extends any>(name: string) {
     const bus = new LocalBus<DispatchDocCmdMsg>();
     bus.subscribe((body) => {
-      this.dispatchListCmd(name, body);
+      const client = this.listClients[name];
+      for (const cb of this.listCallbacksByObjID[name] || []) {
+        cb(client.toArray(), body.from);
+      }
     });
 
     const l = new InnerListClient<T>({
@@ -286,7 +289,10 @@ export class RoomClient {
   private createMapLocally<T extends any>(name: string) {
     const bus = new LocalBus<DispatchDocCmdMsg>();
     bus.subscribe((body) => {
-      this.dispatchMapCmd(name, body);
+      const client = this.mapClients[name];
+      for (const cb of this.mapCallbacksByObjID[name] || []) {
+        cb(client.toObject(), body.from);
+      }
     });
 
     const m = new InnerMapClient<T>({

--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -118,7 +118,7 @@ export class RoomClient {
 
     this.ws.bind('room:rm_guest', (body) => {
       if (body.room !== this.roomID) return;
-      const client = this.presence('_____any') as InnerPresenceClient;
+      const client = this.presence() as InnerPresenceClient;
 
       const newClient = client.dangerouslyUpdateClientDirectly(
         'room:rm_guest',
@@ -162,7 +162,7 @@ export class RoomClient {
     if (body.room !== this.roomID) return;
     if (body.from === this.actor) return;
 
-    const client = this.presence(body.key) as InnerPresenceClient;
+    const client = this.presence() as InnerPresenceClient;
     const key = body.key;
 
     const now = new Date().getTime() / 1000;
@@ -327,7 +327,7 @@ export class RoomClient {
     return this.createMapLocally(name);
   }
 
-  presence(key: string): PresenceClient {
+  presence(): PresenceClient {
     if (this.InnerPresenceClient) {
       return this.InnerPresenceClient;
     }
@@ -348,7 +348,6 @@ export class RoomClient {
       actor: this.actor,
       token: this.token,
       bus,
-      key: key,
     });
     try {
       this.InnerPresenceClient = p;

--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -138,7 +138,7 @@ export class RoomClient {
     const updatedClient = client.dangerouslyUpdateClientDirectly(body.args);
 
     for (const cb of this.mapCallbacksByObjID[objID] || []) {
-      cb(updatedClient, body.from);
+      cb(updatedClient.toObject(), body.from);
     }
   }
 
@@ -151,7 +151,7 @@ export class RoomClient {
     const updatedClient = client.dangerouslyUpdateClientDirectly(body.args);
 
     for (const cb of this.listCallbacksByObjID[objID] || []) {
-      cb(updatedClient, body.from);
+      cb(updatedClient.toArray(), body.from);
     }
   }
 
@@ -356,19 +356,19 @@ export class RoomClient {
 
   subscribe<T>(
     list: ListClient<T>,
-    onChangeFn: (list: ListClient<T>) => any
+    onChangeFn: (list: T[]) => any
   ): ListenerBundle;
   subscribe<T>(
     list: ListClient<T>,
-    onChangeFn: (list: ListClient<T>, from: string) => any
+    onChangeFn: (list: T[], from: string) => any
   ): ListenerBundle;
   subscribe<T>(
     map: MapClient<T>,
-    onChangeFn: (map: MapClient<T>) => {}
+    onChangeFn: (map: { [key: string]: T }) => {}
   ): ListenerBundle;
   subscribe<T>(
     map: MapClient<T>,
-    onChangeFn: (map: MapClient<T>, from: string) => any
+    onChangeFn: (map: { [key: string]: T }, from: string) => any
   ): ListenerBundle;
   subscribe<T extends any>(
     presence: PresenceClient,

--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -6,7 +6,7 @@ import {
   Prop,
 } from './types';
 import { fetchSession, fetchDocument } from './remote';
-import { InnerListClient } from './ListClient';
+import { InnerListClient, ListObject } from './ListClient';
 import { InnerMapClient, MapObject } from './MapClient';
 import { InnerPresenceClient } from './PresenceClient';
 import invariant from 'tiny-invariant';
@@ -36,7 +36,7 @@ export type MapClient<T extends MapObject> = Omit<
   InnerMapClient<T>,
   InternalFunctions | 'id'
 >;
-export type ListClient<T extends any> = Omit<
+export type ListClient<T extends ListObject> = Omit<
   InnerListClient<T>,
   'dangerouslyUpdateClientDirectly' | 'id'
 >;
@@ -244,7 +244,7 @@ export class RoomClient {
     return this.actor;
   }
 
-  private createListLocally<T extends any>(name: string) {
+  private createListLocally<T extends ListObject>(name: string) {
     const bus = new LocalBus<DispatchDocCmdMsg>();
     bus.subscribe((body) => {
       const client = this.listClients[name];
@@ -266,7 +266,7 @@ export class RoomClient {
     return l;
   }
 
-  list<T extends any>(name: string): ListClient<T> {
+  list<T extends ListObject>(name: string): ListClient<T> {
     if (this.listClients[name]) {
       return this.listClients[name];
     }
@@ -364,13 +364,13 @@ export class RoomClient {
   private listCallbacksByObjID: { [key: string]: Array<Function> } = {};
   private presenceCallbacksByKey: { [key: string]: Array<Function> } = {};
 
-  subscribe<T extends any>(
+  subscribe<T extends ListObject>(
     list: ListClient<T>,
-    onChangeFn: (list: T[]) => any
+    onChangeFn: (list: T) => any
   ): ListenerBundle;
-  subscribe<T extends any>(
+  subscribe<T extends ListObject>(
     list: ListClient<T>,
-    onChangeFn: (list: T[], from: string) => any
+    onChangeFn: (list: T, from: string) => any
   ): ListenerBundle;
   subscribe<T extends MapObject>(
     map: MapClient<T>,

--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -6,7 +6,7 @@ import {
   Prop,
 } from './types';
 import { fetchSession, fetchDocument } from './remote';
-import { InnerListClient, ListObject } from './ListClient';
+import { InnerListClient } from './ListClient';
 import { InnerMapClient, MapObject } from './MapClient';
 import { InnerPresenceClient } from './PresenceClient';
 import invariant from 'tiny-invariant';
@@ -36,7 +36,7 @@ export type MapClient<T extends MapObject> = Omit<
   InnerMapClient<T>,
   InternalFunctions | 'id'
 >;
-export type ListClient<T extends ListObject> = Omit<
+export type ListClient<T extends any> = Omit<
   InnerListClient<T>,
   'dangerouslyUpdateClientDirectly' | 'id'
 >;
@@ -244,7 +244,7 @@ export class RoomClient {
     return this.actor;
   }
 
-  private createListLocally<T extends ListObject>(name: string) {
+  private createListLocally<T extends any>(name: string) {
     const bus = new LocalBus<DispatchDocCmdMsg>();
     bus.subscribe((body) => {
       const client = this.listClients[name];
@@ -266,7 +266,7 @@ export class RoomClient {
     return l;
   }
 
-  list<T extends ListObject>(name: string): ListClient<T> {
+  list<T extends any>(name: string): ListClient<T> {
     if (this.listClients[name]) {
       return this.listClients[name];
     }
@@ -364,13 +364,13 @@ export class RoomClient {
   private listCallbacksByObjID: { [key: string]: Array<Function> } = {};
   private presenceCallbacksByKey: { [key: string]: Array<Function> } = {};
 
-  subscribe<T extends ListObject>(
+  subscribe<T extends any>(
     list: ListClient<T>,
-    onChangeFn: (list: T) => any
+    onChangeFn: (list: T[]) => any
   ): ListenerBundle;
-  subscribe<T extends ListObject>(
+  subscribe<T extends any>(
     list: ListClient<T>,
-    onChangeFn: (list: T, from: string) => any
+    onChangeFn: (list: T[], from: string) => any
   ): ListenerBundle;
   subscribe<T extends MapObject>(
     map: MapClient<T>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5987,10 +5987,15 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-typescript@^3.7.3, typescript@^3.8.3:
+typescript@^3.7.3:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+
+typescript@latest:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
+  integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
# Overview

This is a PR for breaking changes to be shipped in a v3. 

## Classes => JSON 

```js
// Before
room.subscribe(todos, nextList => {
  list.toArray() // [1, 2, 3]
})

// After
room.subscribe(todos, array => {
  array // [1, 2, 3]
})
```

## Stronger generic types 

Previously, maps and lists took a generic type for the possible values of the map keys or list items. 

```ts
// In the old version
const map = room.map<string>("mymap")

map.set("foo", 2) // Breaks!
map.set("foo", "bar") // All good
```

Now, you can pass in an entire interface into a map or a list to get key-level typing. For example:

```ts
// In the new version

interface Dog {
  name: string,
  paws: 4,
}

const map = room.map<Dog>("dog")

map.set("foo", "anything") // Breaks!
map.set("paws", 3) // Breaks!
map.set("paws", 4) // All good!
map.set("name", "fluffer") // All good!
```

You even get code completion: 
<img width="355" alt="Screen Shot 2020-11-18 at 11 40 05 AM" src="https://user-images.githubusercontent.com/5942769/99579280-d1fe4c80-2992-11eb-946c-2c01f988f3c8.png">

This also pairs nicely with the new subscription-as-json switch:

```ts
interface Dog {
  name: string,
  paws: 4,
}

const map = room.map<Dog>("dog")

room.subscribe(map, dog => {
  dog.foobar // Breaks!
  dog.name // all good!
})
```

## Make presence match the rest of room service

```ts
// Before 
const p = room.presence()
p.set("key", "value") 

// After
const p = room.presence("key")
p.set("value") 
```
