### PR TITLE
reconnect on websocket failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.0-1",
+  "version": "3.0.0-2",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "typescript": "latest"
   },
   "dependencies": {
-    "@roomservice/core": "0.2.0",
+    "@roomservice/core": "0.2.1-0",
     "tiny-invariant": "^1.1.0"
   }
 }

--- a/src/ListClient.test.ts
+++ b/src/ListClient.test.ts
@@ -1,7 +1,7 @@
 import { LocalBus } from './localbus';
 import { InnerListClient } from './ListClient';
-import { DocumentCheckpoint } from './types';
-import SuperlumeWebSocket from './ws';
+import { DocumentCheckpoint, Prop } from './types';
+import { WebSocketDocCmdMessage } from 'wsMessages';
 
 describe('list clients', () => {
   const checkpoint: DocumentCheckpoint = {
@@ -23,11 +23,7 @@ describe('list clients', () => {
   const docID = 'doc';
   const listID = 'list';
   const send = jest.fn();
-  const ws = new SuperlumeWebSocket({
-    onmessage: jest.fn(),
-    send,
-    readyState: WebSocket.OPEN,
-  });
+  const ws = { send };
 
   test("List clients don't include extra quotes", () => {
     const alpha = new InnerListClient({
@@ -83,11 +79,7 @@ describe('list clients', () => {
 
   test('List Clients send stuff to websockets', () => {
     const send = jest.fn();
-    const ws = new SuperlumeWebSocket({
-      onmessage: jest.fn(),
-      send,
-      readyState: WebSocket.OPEN,
-    });
+    const ws = { send };
 
     const alpha = new InnerListClient({
       checkpoint: checkpoint,
@@ -100,8 +92,8 @@ describe('list clients', () => {
     });
     alpha.push('cats');
 
-    const msg = JSON.parse(send.mock.calls[0][0]) as any;
-    expect(msg.body.args).toEqual([
+    const body = send.mock.calls[0][1] as Prop<WebSocketDocCmdMessage, 'body'>;
+    expect(body.args).toEqual([
       'lins',
       'doc',
       'list',
@@ -113,10 +105,7 @@ describe('list clients', () => {
 
   test('List Clients add stuff to the end of the list', () => {
     const send = jest.fn();
-    const ws = new SuperlumeWebSocket({
-      onmessage: jest.fn(),
-      send,
-    });
+    const ws = { send };
 
     let alpha = new InnerListClient({
       checkpoint,
@@ -173,10 +162,7 @@ describe('list clients', () => {
     };
 
     const send = jest.fn();
-    const ws = new SuperlumeWebSocket({
-      onmessage: jest.fn(),
-      send,
-    });
+    const ws = { send };
 
     let alpha = new InnerListClient({
       checkpoint: fixture.body,

--- a/src/ListClient.ts
+++ b/src/ListClient.ts
@@ -1,4 +1,4 @@
-import SuperlumeWebSocket from './ws';
+import { SuperlumeSend } from './ws';
 import { ObjectClient, DocumentCheckpoint } from './types';
 import invariant from 'tiny-invariant';
 import { LocalBus } from './localbus';
@@ -8,7 +8,7 @@ export type ListObject = Array<any>;
 
 export class InnerListClient<T extends ListObject> implements ObjectClient {
   private roomID: string;
-  private ws: SuperlumeWebSocket;
+  private ws: SuperlumeSend;
   private bus: LocalBus<any>;
   private actor: string;
   private store: ListStore;
@@ -21,7 +21,7 @@ export class InnerListClient<T extends ListObject> implements ObjectClient {
     roomID: string;
     docID: string;
     listID: string;
-    ws: SuperlumeWebSocket;
+    ws: SuperlumeSend;
     actor: string;
     bus: LocalBus<{ args: string[]; from: string }>;
   }) {
@@ -47,6 +47,14 @@ export class InnerListClient<T extends ListObject> implements ObjectClient {
     ListInterpreter.importFromRawCheckpoint(
       this.store,
       props.checkpoint,
+      this.meta.listID
+    );
+  }
+
+  bootstrap(checkpoint: DocumentCheckpoint) {
+    ListInterpreter.importFromRawCheckpoint(
+      this.store,
+      checkpoint,
       this.meta.listID
     );
   }
@@ -141,7 +149,7 @@ export class InnerListClient<T extends ListObject> implements ObjectClient {
     return ListInterpreter.map(this.store, fn);
   }
 
-  toArray(): T[] {
+  toArray(): T[number][] {
     return ListInterpreter.toArray<T[number]>(this.store);
   }
 }

--- a/src/MapClient.test.ts
+++ b/src/MapClient.test.ts
@@ -1,15 +1,11 @@
+import { Prop } from 'types';
 import { LocalBus } from './localbus';
 import { InnerMapClient } from './MapClient';
-import SuperlumeWebSocket from './ws';
 import { WebSocketDocCmdMessage } from './wsMessages';
 
 describe('InnerMapClient', () => {
   const send = jest.fn();
-  const ws = new SuperlumeWebSocket({
-    onmessage: jest.fn(),
-    send,
-    readyState: WebSocket.OPEN,
-  });
+  const ws = { send };
 
   const map = new InnerMapClient({
     // @ts-ignore
@@ -30,22 +26,22 @@ describe('InnerMapClient', () => {
 
   test('sends mput strings', () => {
     map.set('name', 'alice');
-    const msg = JSON.parse(send.mock.calls[0][0]) as WebSocketDocCmdMessage;
-    expect(msg.body.args).toEqual(['mput', 'doc', 'map', 'name', '"alice"']);
+    const body = send.mock.calls[0][1] as Prop<WebSocketDocCmdMessage, 'body'>;
+    expect(body.args).toEqual(['mput', 'doc', 'map', 'name', '"alice"']);
     expect(map.get('name')).toEqual('alice');
   });
 
   test('sends mput numbers', () => {
     map.set('dogs', 2);
-    const msg = JSON.parse(send.mock.calls[1][0]) as WebSocketDocCmdMessage;
-    expect(msg.body.args).toEqual(['mput', 'doc', 'map', 'dogs', '2']);
+    const body = send.mock.calls[1][1] as Prop<WebSocketDocCmdMessage, 'body'>;
+    expect(body.args).toEqual(['mput', 'doc', 'map', 'dogs', '2']);
     expect(map.get('dogs')).toEqual(2);
   });
 
   test('sends mdel', () => {
     map.delete('dogs');
-    const msg = JSON.parse(send.mock.calls[2][0]) as WebSocketDocCmdMessage;
-    expect(msg.body.args).toEqual(['mdel', 'doc', 'map', 'dogs']);
+    const body = send.mock.calls[2][1] as Prop<WebSocketDocCmdMessage, 'body'>;
+    expect(body.args).toEqual(['mdel', 'doc', 'map', 'dogs']);
     expect(map.get('dogs')).toBeFalsy();
   });
 

--- a/src/MapClient.ts
+++ b/src/MapClient.ts
@@ -1,5 +1,5 @@
 import { ObjectClient } from './types';
-import SuperlumeWebSocket from './ws';
+import { SuperlumeSend } from './ws';
 import { LocalBus } from './localbus';
 import {
   MapMeta,
@@ -12,7 +12,7 @@ export type MapObject = { [key: string]: any };
 
 export class InnerMapClient<T extends MapObject> implements ObjectClient {
   private roomID: string;
-  private ws: SuperlumeWebSocket;
+  private ws: SuperlumeSend;
 
   private meta: MapMeta;
   private store: MapStore<any>;
@@ -25,7 +25,7 @@ export class InnerMapClient<T extends MapObject> implements ObjectClient {
     docID: string;
     mapID: string;
     actor: string;
-    ws: SuperlumeWebSocket;
+    ws: SuperlumeSend;
     bus: LocalBus<{ from: string; args: string[] }>;
   }) {
     this.roomID = props.roomID;
@@ -37,9 +37,18 @@ export class InnerMapClient<T extends MapObject> implements ObjectClient {
     this.store = store;
     this.meta = meta;
 
+    //TODO: defer initial bootstrap?
     MapInterpreter.importFromRawCheckpoint(
       this.store,
       props.checkpoint,
+      this.meta.mapID
+    );
+  }
+
+  public bootstrap(checkpoint: DocumentCheckpoint) {
+    MapInterpreter.importFromRawCheckpoint(
+      this.store,
+      checkpoint,
       this.meta.mapID
     );
   }

--- a/src/PresenceClient.ts
+++ b/src/PresenceClient.ts
@@ -51,17 +51,13 @@ export class InnerPresenceClient {
     );
     this.cache[key] = val;
 
-    return this.withoutExpiredAndSelf(key);
+    return this.withoutExpired(key);
   }
 
-  private withoutExpiredAndSelf(key: string) {
+  private withoutExpired(key: string) {
     const result = {} as { [key: string]: any };
     for (let actor in this.cache[key]) {
       const obj = this.cache[key][actor];
-
-      if (actor === this.actor) {
-        delete this.cache[key][actor];
-      }
 
       if (new Date() > obj.expAt) {
         delete this.cache[key][actor];
@@ -138,7 +134,7 @@ export class InnerPresenceClient {
       expAt: new Date(expAt * 1000),
     };
 
-    return this.withoutExpiredAndSelf(key);
+    return this.withoutExpired(key);
   }
 
   dangerouslyUpdateClientDirectly(
@@ -171,7 +167,7 @@ export class InnerPresenceClient {
       return this.withoutActorOrExpired(body.guest);
     }
     if (type === 'presence:expire') {
-      const foo = this.withoutExpiredAndSelf(body.key);
+      const foo = this.withoutExpired(body.key);
       return foo;
     }
 
@@ -188,6 +184,6 @@ export class InnerPresenceClient {
     }
     this.cache[body.key][body.from] = obj;
 
-    return this.withoutExpiredAndSelf(body.key);
+    return this.withoutExpired(body.key);
   }
 }

--- a/src/PresenceClient.ts
+++ b/src/PresenceClient.ts
@@ -1,4 +1,4 @@
-import SuperlumeWebSocket from './ws';
+import { SuperlumeSend } from './ws';
 import { PresenceCheckpoint, Prop } from './types';
 import { fetchPresence } from './remote';
 import { PRESENCE_URL } from './constants';
@@ -11,7 +11,7 @@ import { LocalBus } from 'localbus';
 
 export class InnerPresenceClient {
   private roomID: string;
-  private ws: SuperlumeWebSocket;
+  private ws: SuperlumeSend;
   private actor: string;
   private token: string;
   private cache: { [key: string]: PresenceCheckpoint<any> };
@@ -20,7 +20,7 @@ export class InnerPresenceClient {
 
   constructor(props: {
     roomID: string;
-    ws: SuperlumeWebSocket;
+    ws: SuperlumeSend;
     actor: string;
     token: string;
     bus: LocalBus<{ key: string; value: any; expAt: number }>;

--- a/src/RoomServiceClient.ts
+++ b/src/RoomServiceClient.ts
@@ -1,6 +1,6 @@
-import { WS_URL, DOCS_URL } from './constants';
+import { DOCS_URL } from './constants';
 import { createRoom, RoomClient } from './RoomClient';
-import { WebSocketLikeConnection, AuthStrategy, AuthFunction } from 'types';
+import { AuthStrategy, AuthFunction } from 'types';
 
 interface SimpleAuthParams {
   auth: string;
@@ -30,9 +30,7 @@ export class RoomService<T extends object> {
       return this.roomClients[name];
     }
 
-    const ws = new WebSocket(WS_URL);
     const client = await createRoom<T>({
-      conn: ws as WebSocketLikeConnection,
       docsURL: DOCS_URL,
       authStrategy: this.auth,
       authCtx: this.ctx,

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,7 +78,7 @@ type RequireSome<T, K extends keyof T> = Partial<Omit<T, K>> &
 
 export type WebSocketLikeConnection = RequireSome<
   WebSocket,
-  'send' | 'onmessage'
+  'send' | 'onmessage' | 'close'
 >;
 
 export interface DocumentContext {

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,3 +5,7 @@ export function unescapeID(checkpoint: DocumentCheckpoint, id: string): string {
   let [index, a] = id.split(':');
   return index + ':' + checkpoint.actors[parseInt(a)];
 }
+
+export function delay(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1068,10 +1068,10 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
-"@roomservice/core@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@roomservice/core/-/core-0.2.0.tgz#6ac3376d95b39ad91709b074a31a5026f362e792"
-  integrity sha512-85r9PjDIy1+7I3J8ni6Vkd2gCoiYbjjxijtDc1g6FMPBIE4IV13x3tOYNb00OClhmXJuIgWtBiGxONN9J37qdA==
+"@roomservice/core@0.2.1-0":
+  version "0.2.1-0"
+  resolved "https://registry.yarnpkg.com/@roomservice/core/-/core-0.2.1-0.tgz#898ffbc25ffef9f42dbbfb1115844bd2f9746ee2"
+  integrity sha512-ubMRNE0t+DHvaMsrfa14RHvPXljW60/bRa0bLBVeR99uCWzJ5sLgwt3qIjE3ki3hmyDSuoxhm91eIgibYLkKjA==
   dependencies:
     tiny-invariant "^1.1.0"
 


### PR DESCRIPTION
note: based off of v3 PR, and requires the latest version of `@roomservice/core`

This pull request adds automatic reconnection to the underlying websocket layer. It is also a step towards being able to run completely offline-first (which would likely require some client-side persistence between page reloads).

Fault tolerance model: 
- On load, the fetching of the session and first document bootstrap must succeed, or we throw to the caller.
- When the websocket is offline, commands created locally are queued to be sent once we do reconnect. We will try indefinitely (waiting between 1 and 2 minutes at the maximum of the backoff) to reconnect to wsgateway.
- Once a live connection is re-established, incoming commands are queued and a new bootstrap is performed
- After the bootstrap has finished, incoming queued commands that are _newer_ than the new checkpoint are applied
> Note that we rebootstrap completely in case we missed some document updates while offline

Code architecture:
- A `WebsocketDispatch` interface defines the interaction between `RoomClient` and `ReconnectingWebsocket`.
- The websocket wrapper, now `ReconnectingWebSocket`, is still passed directly to clients, who use it through the `SuperlumeSend` interface.
- Incoming commands are routed to clients through `RoomClient`'s `WebsocketDispatch` method implementations