### PR TITLE
merge response of presence.getAll to prevent data loss

### DIFF
--- a/src/PresenceClient.ts
+++ b/src/PresenceClient.ts
@@ -54,7 +54,11 @@ export class InnerPresenceClient {
       this.roomID,
       key
     );
-    this.cache[key] = val;
+    //  only initialize non-present values so we don't lose actors not present in this checkpoint
+    this.cache[key] = {
+      ...val,
+      ...(this.cache[key] || {}),
+    };
 
     return this.withoutExpired(key);
   }


### PR DESCRIPTION
this manifested when setting a value for presence immediately in a `useEffect`. the later `getAll` method would wipe away this value because that response hits the server before the cmd to set the original value does.