### PR TITLE
small presence rearchitecture

### DIFF
--- a/example/pages/presence.tsx
+++ b/example/pages/presence.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import RoomService from '../../dist';
+import RoomService, { RoomClient } from '../../dist';
 
 const useInterval = (callback, delay) => {
   const savedCallback = useRef() as any;
@@ -24,21 +24,22 @@ const rs = new RoomService({
 });
 
 export default function Presence() {
-  const [room, setRoom] = useState();
+  const [room, setRoom] = useState<RoomClient>();
   const [first, setFirst] = useState<any>({});
   const [second, setSecond] = useState<any>({});
 
   useEffect(() => {
     async function load() {
       const room = await rs.room('presence-demo');
-      const p = room.presence();
-      setRoom(room as any);
+      const first = room.presence('first');
+      const second = room.presence('second');
+      setRoom(room);
 
-      room.subscribe(p, 'first', (val) => {
+      room.subscribe(first, (val) => {
         setFirst(val);
       });
 
-      room.subscribe(p, 'second', (val) => {
+      room.subscribe(second, (val) => {
         setSecond(val);
       });
     }
@@ -47,10 +48,10 @@ export default function Presence() {
 
   useInterval(() => {
     if (room === undefined) return;
-    // @ts-ignore
-    room!.presence().set('first', new Date().toTimeString());
-    // @ts-ignore
-    room!.presence().set('second', new Date().toTimeString());
+    if (room) {
+      room?.presence('first').set(new Date().toTimeString());
+      room?.presence('second').set(new Date().toTimeString());
+    }
   }, 1000);
 
   return (

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.0-7",
+  "version": "3.0.0-8",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.0-6",
+  "version": "3.0.0-7",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.0-8",
+  "version": "3.0.0-9",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.0-9",
+  "version": "3.0.0-10",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/ListClient.ts
+++ b/src/ListClient.ts
@@ -3,6 +3,7 @@ import { ObjectClient, DocumentCheckpoint } from './types';
 import invariant from 'tiny-invariant';
 import { LocalBus } from './localbus';
 import { ListInterpreter, ListMeta, ListStore } from '@roomservice/core';
+import { BootstrapState } from 'remote';
 
 export type ListObject = Array<any>;
 
@@ -51,10 +52,10 @@ export class InnerListClient<T extends ListObject> implements ObjectClient {
     );
   }
 
-  bootstrap(checkpoint: DocumentCheckpoint) {
+  bootstrap(checkpoint: BootstrapState) {
     ListInterpreter.importFromRawCheckpoint(
       this.store,
-      checkpoint,
+      checkpoint.document,
       this.meta.listID
     );
   }

--- a/src/MapClient.ts
+++ b/src/MapClient.ts
@@ -7,6 +7,7 @@ import {
   MapInterpreter,
   DocumentCheckpoint,
 } from '@roomservice/core';
+import { BootstrapState } from 'remote';
 
 export type MapObject = { [key: string]: any };
 
@@ -45,10 +46,10 @@ export class InnerMapClient<T extends MapObject> implements ObjectClient {
     );
   }
 
-  public bootstrap(checkpoint: DocumentCheckpoint) {
+  public bootstrap(checkpoint: BootstrapState) {
     MapInterpreter.importFromRawCheckpoint(
       this.store,
-      checkpoint,
+      checkpoint.document,
       this.meta.mapID
     );
   }

--- a/src/PresenceClient.ts
+++ b/src/PresenceClient.ts
@@ -21,7 +21,7 @@ export class InnerPresenceClient<T extends any> {
   private cache: PresenceCheckpoint<T>;
   private sendPres: (key: string, args: any) => any;
   private bus: LocalBus<LocalPresenceUpdate>;
-  private key: string;
+  key: string;
 
   constructor(props: {
     roomID: string;

--- a/src/PresenceClient.ts
+++ b/src/PresenceClient.ts
@@ -54,8 +54,8 @@ export class InnerPresenceClient<T extends any> {
   }
 
   /**
-   * Gets all values for an identifier, organized by user id.
-   * @param key the identifier. Ex: "position"
+   * Gets all values for the presence key this client was created with,
+   * organized by user id.
    */
   getAll(): ValuesByUser<T> {
     //  only initialize non-present values so we don't lose actors not present in this checkpoint
@@ -63,8 +63,11 @@ export class InnerPresenceClient<T extends any> {
     return this.withoutExpired();
   }
 
-  my<T extends any>(): T | undefined {
-    return (this.cache || {})[this.actor] as T | undefined;
+  /**
+   * Gets the current user's value.
+   */
+  getMine(): T | undefined {
+    return (this.cache || {})[this.actor]?.value;
   }
 
   private withoutExpired(): ValuesByUser<T> {

--- a/src/PresenceClient.ts
+++ b/src/PresenceClient.ts
@@ -1,5 +1,5 @@
 import { SuperlumeSend } from './ws';
-import { PresenceCheckpoint, Prop } from './types';
+import { DocumentCheckpoint, PresenceCheckpoint, Prop } from './types';
 import { fetchPresence } from './remote';
 import { PRESENCE_URL } from './constants';
 import {
@@ -46,6 +46,13 @@ export class InnerPresenceClient<T extends any> {
       this.ws.send('presence:cmd', args);
     };
     this.sendPres = throttleByFirstArgument(sendPres, 40);
+  }
+
+  bootstrap(checkpoint: DocumentCheckpoint) {
+    this.cache = {
+      ...this.cache,
+      ...(checkpoint.presence[this.key] || {}),
+    };
   }
 
   /**

--- a/src/PresenceClient.ts
+++ b/src/PresenceClient.ts
@@ -59,8 +59,6 @@ export class InnerPresenceClient<T extends any> {
    * organized by user id.
    */
   getAll(): ValuesByUser<T> {
-    //  only initialize non-present values so we don't lose actors not present in this checkpoint
-
     return this.withoutExpired();
   }
 
@@ -72,7 +70,7 @@ export class InnerPresenceClient<T extends any> {
   }
 
   private withoutExpired(): ValuesByUser<T> {
-    const result = {} as { [key: string]: any };
+    const result = {} as ValuesByUser<T>;
     for (let actor in this.cache) {
       const obj = this.cache[actor];
 
@@ -87,26 +85,24 @@ export class InnerPresenceClient<T extends any> {
   }
 
   private withoutActorOrExpired(actor: string): ValuesByUser<T> {
-    const result = {} as { [key: string]: any };
-    for (let key in this.cache) {
-      for (let a in this.cache[key]) {
-        const obj = this.cache[a];
-        if (!obj) continue;
+    const result = {} as ValuesByUser<T>;
+    for (let a in this.cache) {
+      const obj = this.cache[a];
+      if (!obj) continue;
 
-        // remove this actor
-        if (a === actor && this.cache[a]) {
-          delete this.cache[a];
-          continue;
-        }
-
-        // Remove expired
-        if (new Date() > obj.expAt) {
-          delete this.cache[a];
-          continue;
-        }
-
-        result[a] = obj.value;
+      // remove this actor
+      if (a === actor && this.cache[a]) {
+        delete this.cache[a];
+        continue;
       }
+
+      // Remove expired
+      if (new Date() > obj.expAt) {
+        delete this.cache[a];
+        continue;
+      }
+
+      result[a] = obj.value;
     }
     return result;
   }

--- a/src/PresenceClient.ts
+++ b/src/PresenceClient.ts
@@ -1,11 +1,12 @@
 import { SuperlumeSend } from './ws';
-import { DocumentCheckpoint, PresenceCheckpoint, Prop } from './types';
+import { PresenceCheckpoint, Prop } from './types';
 import {
   WebSocketPresenceFwdMessage,
   WebSocketLeaveMessage,
 } from './wsMessages';
 import { throttleByFirstArgument } from './throttle';
 import { LocalBus } from 'localbus';
+import { BootstrapState } from 'remote';
 
 export type LocalPresenceUpdate = {
   key: string;
@@ -25,7 +26,7 @@ export class InnerPresenceClient<T extends any> {
 
   constructor(props: {
     roomID: string;
-    checkpoint: DocumentCheckpoint;
+    checkpoint: BootstrapState;
     ws: SuperlumeSend;
     actor: string;
     key: string;
@@ -46,7 +47,7 @@ export class InnerPresenceClient<T extends any> {
     this.bootstrap(props.checkpoint);
   }
 
-  bootstrap(checkpoint: DocumentCheckpoint) {
+  bootstrap(checkpoint: BootstrapState) {
     this.cache = {
       ...this.cache,
       ...(checkpoint.presence[this.key] || {}),

--- a/src/PresenceClient.ts
+++ b/src/PresenceClient.ts
@@ -1,7 +1,5 @@
 import { SuperlumeSend } from './ws';
 import { DocumentCheckpoint, PresenceCheckpoint, Prop } from './types';
-import { fetchPresence } from './remote';
-import { PRESENCE_URL } from './constants';
 import {
   WebSocketPresenceFwdMessage,
   WebSocketLeaveMessage,
@@ -20,7 +18,6 @@ export class InnerPresenceClient<T extends any> {
   private roomID: string;
   private ws: SuperlumeSend;
   private actor: string;
-  private token: string;
   private cache: PresenceCheckpoint<T>;
   private sendPres: (key: string, args: any) => any;
   private bus: LocalBus<LocalPresenceUpdate>;
@@ -30,14 +27,12 @@ export class InnerPresenceClient<T extends any> {
     roomID: string;
     ws: SuperlumeSend;
     actor: string;
-    token: string;
     key: string;
     bus: LocalBus<LocalPresenceUpdate>;
   }) {
     this.roomID = props.roomID;
     this.ws = props.ws;
     this.actor = props.actor;
-    this.token = props.token;
     this.key = props.key;
     this.cache = {};
     this.bus = props.bus;

--- a/src/PresenceClient.ts
+++ b/src/PresenceClient.ts
@@ -11,29 +11,34 @@ import { LocalBus } from 'localbus';
 
 export type LocalPresenceUpdate = {
   key: string;
-  valuesByActor: { [key: string]: any };
+  valuesByUser: { [key: string]: any };
 };
 
-export class InnerPresenceClient {
+type ValuesByUser<T extends any> = { [key: string]: T };
+
+export class InnerPresenceClient<T extends any> {
   private roomID: string;
   private ws: SuperlumeSend;
   private actor: string;
   private token: string;
-  private cache: { [key: string]: PresenceCheckpoint<any> };
+  private cache: PresenceCheckpoint<T>;
   private sendPres: (key: string, args: any) => any;
   private bus: LocalBus<LocalPresenceUpdate>;
+  private key: string;
 
   constructor(props: {
     roomID: string;
     ws: SuperlumeSend;
     actor: string;
     token: string;
+    key: string;
     bus: LocalBus<LocalPresenceUpdate>;
   }) {
     this.roomID = props.roomID;
     this.ws = props.ws;
     this.actor = props.actor;
     this.token = props.token;
+    this.key = props.key;
     this.cache = {};
     this.bus = props.bus;
 
@@ -47,29 +52,23 @@ export class InnerPresenceClient {
    * Gets all values for an identifier, organized by user id.
    * @param key the identifier. Ex: "position"
    */
-  async getAll<T extends any>(key: string): Promise<{ [key: string]: T }> {
-    const val = await fetchPresence<T>(
-      PRESENCE_URL,
-      this.token,
-      this.roomID,
-      key
-    );
+  getAll(): ValuesByUser<T> {
     //  only initialize non-present values so we don't lose actors not present in this checkpoint
-    this.cache[key] = {
-      ...val,
-      ...(this.cache[key] || {}),
-    };
 
-    return this.withoutExpired(key);
+    return this.withoutExpired();
   }
 
-  private withoutExpired(key: string): { [key: string]: any } {
+  my<T extends any>(): T | undefined {
+    return (this.cache || {})[this.actor] as T | undefined;
+  }
+
+  private withoutExpired(): ValuesByUser<T> {
     const result = {} as { [key: string]: any };
-    for (let actor in this.cache[key]) {
-      const obj = this.cache[key][actor];
+    for (let actor in this.cache) {
+      const obj = this.cache[actor];
 
       if (new Date() > obj.expAt) {
-        delete this.cache[key][actor];
+        delete this.cache[actor];
         continue;
       }
       result[actor] = obj.value;
@@ -78,22 +77,22 @@ export class InnerPresenceClient {
     return result;
   }
 
-  private withoutActorOrExpired(actor: string) {
+  private withoutActorOrExpired(actor: string): ValuesByUser<T> {
     const result = {} as { [key: string]: any };
     for (let key in this.cache) {
       for (let a in this.cache[key]) {
-        const obj = this.cache[key][a];
+        const obj = this.cache[a];
         if (!obj) continue;
 
         // remove this actor
-        if (a === actor && this.cache[key][a]) {
-          delete this.cache[key][a];
+        if (a === actor && this.cache[a]) {
+          delete this.cache[a];
           continue;
         }
 
         // Remove expired
         if (new Date() > obj.expAt) {
-          delete this.cache[key][a];
+          delete this.cache[a];
           continue;
         }
 
@@ -103,46 +102,29 @@ export class InnerPresenceClient {
     return result;
   }
 
-  // Deprecated
-  get me() {
-    console.warn(
-      'presence.me() is deprecated and will be removed in a future version!'
-    );
-    return this.actor;
-  }
-
   /**
-   * @param key
    * @param value Any arbitrary object, string, boolean, or number.
    * @param exp (Optional) Expiration time in seconds
    */
-  set<T extends any>(
-    key: string,
-    value: T,
-    exp?: number
-  ): { [key: string]: T } {
+  set(value: T, exp?: number): { [key: string]: T } {
     let addition = exp ? exp : 60;
     // Convert to unix + add seconds
     const expAt = Math.round(new Date().getTime() / 1000) + addition;
 
-    this.sendPres(key, {
+    this.sendPres(this.key, {
       room: this.roomID,
-      key: key,
+      key: this.key,
       value: JSON.stringify(value),
       expAt: expAt,
     });
 
-    if (!this.cache[key]) {
-      this.cache[key] = {};
-    }
-
-    this.cache[key][this.actor] = {
+    this.cache[this.actor] = {
       value,
       expAt: new Date(expAt * 1000),
     };
 
-    const result = this.withoutExpired(key);
-    this.bus.publish({ key, valuesByActor: result });
+    const result = this.withoutExpired();
+    this.bus.publish({ key: this.key, valuesByUser: result });
 
     return result;
   }
@@ -177,7 +159,7 @@ export class InnerPresenceClient {
       return this.withoutActorOrExpired(body.guest);
     }
     if (type === 'presence:expire') {
-      const foo = this.withoutExpired(body.key);
+      const foo = this.withoutExpired();
       return foo;
     }
 
@@ -189,11 +171,8 @@ export class InnerPresenceClient {
       value: JSON.parse(body.value),
     };
 
-    if (!this.cache[body.key]) {
-      this.cache[body.key] = {};
-    }
-    this.cache[body.key][body.from] = obj;
+    this.cache[body.from] = obj;
 
-    return this.withoutExpired(body.key);
+    return this.withoutExpired();
   }
 }

--- a/src/PresenceClient.ts
+++ b/src/PresenceClient.ts
@@ -25,6 +25,7 @@ export class InnerPresenceClient<T extends any> {
 
   constructor(props: {
     roomID: string;
+    checkpoint: DocumentCheckpoint;
     ws: SuperlumeSend;
     actor: string;
     key: string;
@@ -41,6 +42,8 @@ export class InnerPresenceClient<T extends any> {
       this.ws.send('presence:cmd', args);
     };
     this.sendPres = throttleByFirstArgument(sendPres, 40);
+
+    this.bootstrap(props.checkpoint);
   }
 
   bootstrap(checkpoint: DocumentCheckpoint) {

--- a/src/RoomClient.test.ts
+++ b/src/RoomClient.test.ts
@@ -40,6 +40,7 @@ function mockRoomClient(): RoomClient {
     session,
     wsURL: 'wss://websocket.invalid',
     docsURL: 'https://docs.invalid',
+    presenceURL: 'https://presence.invalid',
     actor: 'me',
     bootstrapState,
     token: session.token,

--- a/src/RoomClient.test.ts
+++ b/src/RoomClient.test.ts
@@ -1,6 +1,6 @@
 import { RoomClient } from './RoomClient';
 import { DocumentCheckpoint } from './types';
-import { LocalSession } from 'remote';
+import { BootstrapState, LocalSession } from 'remote';
 
 export function mockSession(): LocalSession {
   return {
@@ -23,9 +23,16 @@ export function mockCheckpoint(): DocumentCheckpoint {
   };
 }
 
+export function mockBootstrapState(): BootstrapState {
+  return {
+    document: mockCheckpoint(),
+    presence: {},
+  };
+}
+
 function mockRoomClient(): RoomClient {
   const session = mockSession();
-  const checkpoint = mockCheckpoint();
+  const bootstrapState = mockBootstrapState();
 
   return new RoomClient({
     auth: 'xyz',
@@ -34,7 +41,7 @@ function mockRoomClient(): RoomClient {
     wsURL: 'wss://websocket.invalid',
     docsURL: 'https://docs.invalid',
     actor: 'me',
-    checkpoint,
+    bootstrapState,
     token: session.token,
     roomID: session.roomID,
     docID: session.docID,

--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -185,6 +185,7 @@ export class RoomClient implements WebsocketDispatch {
         'room:rm_guest',
         body
       );
+      if (!newClient) return;
       for (const cb of this.presenceCallbacksByKey[key] || []) {
         cb(newClient, body.guest);
       }

--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -52,7 +52,6 @@ interface DispatchDocCmdMsg {
 }
 
 export class RoomClient implements WebsocketDispatch {
-  private token: string;
   private roomID: string;
   private docID: string;
   private actor: string;
@@ -85,7 +84,6 @@ export class RoomClient implements WebsocketDispatch {
       room: roomID,
       session: params.session,
     });
-    this.token = params.token;
     this.roomID = params.roomID;
     this.docID = params.checkpoint.id;
     this.actor = params.actor;
@@ -359,7 +357,6 @@ export class RoomClient implements WebsocketDispatch {
       roomID: this.roomID,
       ws: this.ws,
       actor: this.actor,
-      token: this.token,
       key,
       bus,
     });

--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -121,6 +121,9 @@ export class RoomClient implements WebsocketDispatch {
     for (const [_, client] of Object.entries(this.mapClients)) {
       client.bootstrap(checkpoint);
     }
+    for (const [_, client] of Object.entries(this.presenceClients)) {
+      client.bootstrap(checkpoint);
+    }
     this.queueIncomingCmds = false;
     for (const [msgType, body] of this.cmdQueue) {
       this.processCmd(msgType, body);

--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -354,6 +354,7 @@ export class RoomClient implements WebsocketDispatch {
     });
 
     const p = new InnerPresenceClient<T>({
+      checkpoint: this.checkpoint,
       roomID: this.roomID,
       ws: this.ws,
       actor: this.actor,

--- a/src/RoomServiceClient.ts
+++ b/src/RoomServiceClient.ts
@@ -1,4 +1,4 @@
-import { DOCS_URL } from './constants';
+import { DOCS_URL, PRESENCE_URL } from './constants';
 import { createRoom, RoomClient } from './RoomClient';
 import { AuthStrategy, AuthFunction } from 'types';
 
@@ -32,6 +32,7 @@ export class RoomService<T extends object> {
 
     const client = await createRoom<T>({
       docsURL: DOCS_URL,
+      presenceURL: PRESENCE_URL,
       authStrategy: this.auth,
       authCtx: this.ctx,
       room: name,

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -12,7 +12,8 @@ export interface BootstrapState {
 }
 
 export async function fetchBootstrapState(props: {
-  url: string;
+  docsURL: string;
+  presenceURL: string;
   token: string;
   roomID: string;
   docID: string;
@@ -21,8 +22,8 @@ export async function fetchBootstrapState(props: {
     AllPresence,
     DocumentCheckpoint
   >([
-    fetchPresence(props.url, props.token, props.roomID),
-    fetchDocument(props.url, props.token, props.docID),
+    fetchPresence(props.presenceURL, props.token, props.roomID),
+    fetchDocument(props.docsURL, props.token, props.docID),
   ]);
 
   return {

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -46,8 +46,8 @@ export async function fetchPresence(
   const doc = (await res.json()) as { [key: string]: PresenceCheckpoint<any> };
 
   // Parse JSON values
-  for (let key in Object.keys(doc)) {
-    for (let actor in Object.keys(doc[key])) {
+  for (let key of Object.keys(doc)) {
+    for (let actor of Object.keys(doc[key])) {
       if (typeof doc[key][actor].value === 'string') {
         let json;
         try {

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,7 +28,6 @@ export interface DocumentCheckpoint {
   actors: { [key: number]: string };
   lists: { [key: string]: ListCheckpoint };
   maps: { [key: string]: MapCheckpoint };
-  presence: { [key: string]: PresenceCheckpoint<any> };
 }
 
 interface PresenceObject<T> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import ReverseTree from './ReverseTree';
+import { ReverseTree } from '@roomservice/core/dist/ReverseTree';
 
 export interface Ref {
   type: 'map' | 'list';
@@ -28,6 +28,7 @@ export interface DocumentCheckpoint {
   actors: { [key: number]: string };
   lists: { [key: string]: ListCheckpoint };
   maps: { [key: string]: MapCheckpoint };
+  presence: { [key: string]: PresenceCheckpoint<any> };
 }
 
 interface PresenceObject<T> {

--- a/src/ws.test.ts
+++ b/src/ws.test.ts
@@ -39,6 +39,7 @@ function mockReconnectingWS(
     dispatcher: mockDispatch(),
     wsURL: 'wss://ws.invalid',
     docsURL: 'https://docs.invalid',
+    presenceURL: 'https://presence.invalid',
     room: 'mock-room',
     session: mockSession(),
     wsFactory: makeTestWSFactory(send, onmessage),

--- a/src/ws.test.ts
+++ b/src/ws.test.ts
@@ -1,7 +1,7 @@
 import { mockSession } from './RoomClient.test';
 import { Prop } from 'types';
 import {
-  DocumentFetch,
+  BootstrapFetch,
   ReconnectingWebSocket,
   WebsocketDispatch,
   WebSocketFactory,
@@ -33,7 +33,7 @@ function mockDispatch(): WebsocketDispatch {
 function mockReconnectingWS(
   send: Prop<WebSocket, 'send'>,
   onmessage: Prop<WebSocket, 'onmessage'>,
-  fetch: DocumentFetch
+  fetch: BootstrapFetch
 ): ReconnectingWebSocket {
   return new ReconnectingWebSocket({
     dispatcher: mockDispatch(),
@@ -42,7 +42,7 @@ function mockReconnectingWS(
     room: 'mock-room',
     session: mockSession(),
     wsFactory: makeTestWSFactory(send, onmessage),
-    documentFetch: fetch,
+    bootstrapFetch: fetch,
   });
 }
 

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -22,6 +22,7 @@ const FORWARDED_TYPES = ['doc:fwd', 'presence:fwd', 'room:rm_guest'];
 export class ReconnectingWebSocket implements SuperlumeSend {
   private wsURL: string;
   private docsURL: string;
+  private presenceURL: string;
   private room: string;
 
   private session: LocalSession;
@@ -40,6 +41,7 @@ export class ReconnectingWebSocket implements SuperlumeSend {
     dispatcher: WebsocketDispatch;
     wsURL: string;
     docsURL: string;
+    presenceURL: string;
     room: string;
     session: LocalSession;
     wsFactory?: WebSocketFactory;
@@ -48,6 +50,7 @@ export class ReconnectingWebSocket implements SuperlumeSend {
     this.dispatcher = params.dispatcher;
     this.wsURL = params.wsURL;
     this.docsURL = params.docsURL;
+    this.presenceURL = params.presenceURL;
     this.room = params.room;
     this.session = params.session;
     this.wsFactory = params.wsFactory || openWS;
@@ -89,7 +92,8 @@ export class ReconnectingWebSocket implements SuperlumeSend {
       const bootstrapState = await this.bootstrapFetch({
         docID: this.session.docID,
         roomID: this.session.roomID,
-        url: this.docsURL,
+        docsURL: this.docsURL,
+        presenceURL: this.presenceURL,
         token: this.session.token,
       });
 
@@ -347,7 +351,8 @@ export type WebSocketTransport = Pick<
 >;
 
 export type BootstrapFetch = (props: {
-  url: string;
+  docsURL: string;
+  presenceURL: string;
   token: string;
   roomID: string;
   docID: string;

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -8,15 +8,9 @@ import {
   WebSocketLeaveMessage,
   WebSocketJoinMessage,
 } from './wsMessages';
-import {
-  WebSocketLikeConnection,
-  Prop,
-  DocumentCheckpoint,
-  Message,
-} from 'types';
-import { LocalSession } from './remote';
+import { WebSocketLikeConnection, Prop } from 'types';
+import { BootstrapState, fetchBootstrapState, LocalSession } from './remote';
 import { delay } from './util';
-import { fetchDocument } from './remote';
 type Cb = (body: any) => void;
 
 const WEBSOCKET_TIMEOUT = 1000 * 2;
@@ -33,7 +27,7 @@ export class ReconnectingWebSocket implements SuperlumeSend {
   private session: LocalSession;
 
   private wsFactory: WebSocketFactory;
-  private documentFetch: DocumentFetch;
+  private bootstrapFetch: BootstrapFetch;
 
   // Invariant: at most 1 of current/pendingConn are present
   private currentConn?: WebSocketLikeConnection;
@@ -49,7 +43,7 @@ export class ReconnectingWebSocket implements SuperlumeSend {
     room: string;
     session: LocalSession;
     wsFactory?: WebSocketFactory;
-    documentFetch?: DocumentFetch;
+    bootstrapFetch?: BootstrapFetch;
   }) {
     this.dispatcher = params.dispatcher;
     this.wsURL = params.wsURL;
@@ -57,7 +51,7 @@ export class ReconnectingWebSocket implements SuperlumeSend {
     this.room = params.room;
     this.session = params.session;
     this.wsFactory = params.wsFactory || openWS;
-    this.documentFetch = params.documentFetch || fetchDocument;
+    this.bootstrapFetch = params.bootstrapFetch || fetchBootstrapState;
 
     this.wsLoop();
   }
@@ -92,13 +86,14 @@ export class ReconnectingWebSocket implements SuperlumeSend {
       ws.send(this.serializeMsg('room:join', this.room));
       await this.once('room:joined');
 
-      const { body } = await this.documentFetch(
-        this.docsURL,
-        this.session.token,
-        this.session.docID
-      );
+      const bootstrapState = await this.bootstrapFetch({
+        docID: this.session.docID,
+        roomID: this.session.roomID,
+        url: this.docsURL,
+        token: this.session.token,
+      });
 
-      this.dispatcher.bootstrap(body);
+      this.dispatcher.bootstrap(bootstrapState);
 
       return ws;
     });
@@ -319,7 +314,7 @@ export type ForwardedMessageBody =
 
 export interface WebsocketDispatch {
   forwardCmd(type: string, body: ForwardedMessageBody): void;
-  bootstrap(checkpoint: DocumentCheckpoint): void;
+  bootstrap(state: BootstrapState): void;
   startQueueingCmds(): void;
 }
 
@@ -351,8 +346,9 @@ export type WebSocketTransport = Pick<
   'send' | 'onclose' | 'onmessage' | 'onerror' | 'close'
 >;
 
-export type DocumentFetch = (
-  url: string,
-  token: string,
-  docID: string
-) => Promise<Message<DocumentCheckpoint>>;
+export type BootstrapFetch = (props: {
+  url: string;
+  token: string;
+  roomID: string;
+  docID: string;
+}) => Promise<BootstrapState>;


### PR DESCRIPTION
NOTE: requires a small server change to include presence in the doc checkpoint. the bootstrap service already serves presence data so should be a simple change, and it's completely backwards compatible

These changes were motivated by differences in bootstrappnig logic between presence and lists/maps. I also needed a simple and synchronous way to get the current state for use in the new `usePresence` update fn method for setting a new value. Finally, the generic type parameters present before weren't really doing anything because they were all on methods instead of on the clients themselves. I moved them all to the client (which was the main motivation behind scoping clients to a single `key`).

- scope `PresenceClient` to a single key (similar to how map + list clients correspond to one map/list)
- bootstrap `PresenceClient` at the same time as list/map clients
  - including on reconnect
- remove fetching from `getAll` because bootstrap is taken care of by reconnecting WS logic
  - this also makes `getAll` sync
- add `my()` (what's a better name for this?) function to get user's own value easily
- remove `key` arg from `room.subscribe(<presenceclient>, ...)` because clients are now scoped to a key
