### PR TITLE
some offline/reconnect related work

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "typescript": "latest"
   },
   "dependencies": {
-    "@roomservice/core": "0.2.1",
+    "@roomservice/core": "0.3.1",
     "tiny-invariant": "^1.1.0"
   }
 }

--- a/src/ListClient.ts
+++ b/src/ListClient.ts
@@ -8,6 +8,7 @@ import { BootstrapState } from 'remote';
 export type ListObject = Array<any>;
 
 export class InnerListClient<T extends ListObject> implements ObjectClient {
+  private roomID: string;
   private ws: SuperlumeSend;
   private bus: LocalBus<any>;
   private actor: string;
@@ -18,12 +19,14 @@ export class InnerListClient<T extends ListObject> implements ObjectClient {
 
   constructor(props: {
     checkpoint: DocumentCheckpoint;
+    roomID: string;
     docID: string;
     listID: string;
     ws: SuperlumeSend;
     actor: string;
     bus: LocalBus<{ args: string[]; from: string }>;
   }) {
+    this.roomID = props.roomID;
     this.ws = props.ws;
     this.bus = props.bus;
     this.actor = props.actor;
@@ -62,6 +65,7 @@ export class InnerListClient<T extends ListObject> implements ObjectClient {
 
   private sendCmd(cmd: string[]) {
     this.ws.send('doc:cmd', {
+      room: this.roomID,
       args: cmd,
     });
 

--- a/src/ListClient.ts
+++ b/src/ListClient.ts
@@ -47,14 +47,17 @@ export class InnerListClient<T extends ListObject> implements ObjectClient {
 
     ListInterpreter.importFromRawCheckpoint(
       this.store,
+      this.actor,
       props.checkpoint,
       this.meta.listID
     );
   }
 
-  bootstrap(checkpoint: BootstrapState) {
+  bootstrap(actor: string, checkpoint: BootstrapState) {
+    this.actor = actor;
     ListInterpreter.importFromRawCheckpoint(
       this.store,
+      this.actor,
       checkpoint.document,
       this.meta.listID
     );

--- a/src/ListClient.ts
+++ b/src/ListClient.ts
@@ -8,7 +8,6 @@ import { BootstrapState } from 'remote';
 export type ListObject = Array<any>;
 
 export class InnerListClient<T extends ListObject> implements ObjectClient {
-  private roomID: string;
   private ws: SuperlumeSend;
   private bus: LocalBus<any>;
   private actor: string;
@@ -19,14 +18,12 @@ export class InnerListClient<T extends ListObject> implements ObjectClient {
 
   constructor(props: {
     checkpoint: DocumentCheckpoint;
-    roomID: string;
     docID: string;
     listID: string;
     ws: SuperlumeSend;
     actor: string;
     bus: LocalBus<{ args: string[]; from: string }>;
   }) {
-    this.roomID = props.roomID;
     this.ws = props.ws;
     this.bus = props.bus;
     this.actor = props.actor;
@@ -65,7 +62,6 @@ export class InnerListClient<T extends ListObject> implements ObjectClient {
 
   private sendCmd(cmd: string[]) {
     this.ws.send('doc:cmd', {
-      room: this.roomID,
       args: cmd,
     });
 

--- a/src/MapClient.ts
+++ b/src/MapClient.ts
@@ -12,7 +12,6 @@ import { BootstrapState } from 'remote';
 export type MapObject = { [key: string]: any };
 
 export class InnerMapClient<T extends MapObject> implements ObjectClient {
-  private roomID: string;
   private ws: SuperlumeSend;
 
   private meta: MapMeta;
@@ -22,14 +21,12 @@ export class InnerMapClient<T extends MapObject> implements ObjectClient {
 
   constructor(props: {
     checkpoint: DocumentCheckpoint;
-    roomID: string;
     docID: string;
     mapID: string;
     actor: string;
     ws: SuperlumeSend;
     bus: LocalBus<{ from: string; args: string[] }>;
   }) {
-    this.roomID = props.roomID;
     this.ws = props.ws;
     this.bus = props.bus;
     this.actor = props.actor;
@@ -61,7 +58,6 @@ export class InnerMapClient<T extends MapObject> implements ObjectClient {
 
   private sendCmd(cmd: string[]) {
     this.ws.send('doc:cmd', {
-      room: this.roomID,
       args: cmd,
     });
 

--- a/src/MapClient.ts
+++ b/src/MapClient.ts
@@ -12,6 +12,7 @@ import { BootstrapState } from 'remote';
 export type MapObject = { [key: string]: any };
 
 export class InnerMapClient<T extends MapObject> implements ObjectClient {
+  private roomID: string;
   private ws: SuperlumeSend;
 
   private meta: MapMeta;
@@ -21,12 +22,14 @@ export class InnerMapClient<T extends MapObject> implements ObjectClient {
 
   constructor(props: {
     checkpoint: DocumentCheckpoint;
+    roomID: string;
     docID: string;
     mapID: string;
     actor: string;
     ws: SuperlumeSend;
     bus: LocalBus<{ from: string; args: string[] }>;
   }) {
+    this.roomID = props.roomID;
     this.ws = props.ws;
     this.bus = props.bus;
     this.actor = props.actor;
@@ -58,6 +61,7 @@ export class InnerMapClient<T extends MapObject> implements ObjectClient {
 
   private sendCmd(cmd: string[]) {
     this.ws.send('doc:cmd', {
+      room: this.roomID,
       args: cmd,
     });
 

--- a/src/MapClient.ts
+++ b/src/MapClient.ts
@@ -46,7 +46,8 @@ export class InnerMapClient<T extends MapObject> implements ObjectClient {
     );
   }
 
-  public bootstrap(checkpoint: BootstrapState) {
+  public bootstrap(actor: string, checkpoint: BootstrapState) {
+    this.actor = actor;
     MapInterpreter.importFromRawCheckpoint(
       this.store,
       checkpoint.document,

--- a/src/PresenceClient.ts
+++ b/src/PresenceClient.ts
@@ -16,6 +16,7 @@ export type LocalPresenceUpdate = {
 type ValuesByUser<T extends any> = { [key: string]: T };
 
 export class InnerPresenceClient<T extends any> {
+  private roomID: string;
   private ws: SuperlumeSend;
   private actor: string;
   private cache: PresenceCheckpoint<T>;
@@ -24,12 +25,14 @@ export class InnerPresenceClient<T extends any> {
   key: string;
 
   constructor(props: {
+    roomID: string;
     checkpoint: BootstrapState;
     ws: SuperlumeSend;
     actor: string;
     key: string;
     bus: LocalBus<LocalPresenceUpdate>;
   }) {
+    this.roomID = props.roomID;
     this.ws = props.ws;
     this.actor = props.actor;
     this.key = props.key;
@@ -116,6 +119,7 @@ export class InnerPresenceClient<T extends any> {
     const expAt = Math.round(new Date().getTime() / 1000) + addition;
 
     this.sendPres(this.key, {
+      room: this.roomID,
       key: this.key,
       value: JSON.stringify(value),
       expAt: expAt,
@@ -166,6 +170,7 @@ export class InnerPresenceClient<T extends any> {
       return foo;
     }
 
+    if (body.room !== this.roomID) return false;
     if (body.from === this.actor) return false; // ignore validation msgs
 
     const obj = {

--- a/src/PresenceClient.ts
+++ b/src/PresenceClient.ts
@@ -24,7 +24,6 @@ export class InnerPresenceClient<T extends any> {
   key: string;
 
   constructor(props: {
-    roomID: string;
     checkpoint: BootstrapState;
     ws: SuperlumeSend;
     actor: string;

--- a/src/PresenceClient.ts
+++ b/src/PresenceClient.ts
@@ -1,5 +1,5 @@
 import { SuperlumeSend } from './ws';
-import { PresenceCheckpoint, Prop } from './types';
+import { PresenceCheckpoint, PresenceObject, Prop } from './types';
 import {
   WebSocketPresenceFwdMessage,
   WebSocketLeaveMessage,
@@ -16,25 +16,22 @@ export type LocalPresenceUpdate = {
 type ValuesByUser<T extends any> = { [key: string]: T };
 
 export class InnerPresenceClient<T extends any> {
-  private roomID: string;
   private ws: SuperlumeSend;
-  private actor: string;
   private cache: PresenceCheckpoint<T>;
   private sendPres: (key: string, args: any) => any;
   private bus: LocalBus<LocalPresenceUpdate>;
   key: string;
 
+  private myValue?: PresenceObject<T> = undefined;
+  private actor?: string;
+
   constructor(props: {
-    roomID: string;
     checkpoint: BootstrapState;
     ws: SuperlumeSend;
-    actor: string;
     key: string;
     bus: LocalBus<LocalPresenceUpdate>;
   }) {
-    this.roomID = props.roomID;
     this.ws = props.ws;
-    this.actor = props.actor;
     this.key = props.key;
     this.cache = {};
     this.bus = props.bus;
@@ -43,8 +40,6 @@ export class InnerPresenceClient<T extends any> {
       this.ws.send('presence:cmd', args);
     };
     this.sendPres = throttleByFirstArgument(sendPres, 40);
-
-    this.bootstrap(this.actor, props.checkpoint);
   }
 
   bootstrap(actor: string, checkpoint: BootstrapState) {
@@ -54,6 +49,12 @@ export class InnerPresenceClient<T extends any> {
       ...this.cache,
       ...(checkpoint.presence[this.key] || {}),
     };
+
+    if (this.myValue !== undefined) {
+      if (this.cache[actor] && this.cache[actor].expAt <= this.myValue.expAt) {
+        this.cache[actor] = this.myValue;
+      }
+    }
   }
 
   /**
@@ -61,6 +62,9 @@ export class InnerPresenceClient<T extends any> {
    * organized by user id.
    */
   getAll(): ValuesByUser<T> {
+    if (!this.actor) {
+      return {};
+    }
     return this.withoutExpired();
   }
 
@@ -68,6 +72,9 @@ export class InnerPresenceClient<T extends any> {
    * Gets the current user's value.
    */
   getMine(): T | undefined {
+    if (!this.actor) {
+      return this.myValue?.value;
+    }
     return (this.cache || {})[this.actor]?.value;
   }
 
@@ -119,12 +126,18 @@ export class InnerPresenceClient<T extends any> {
     const expAt = Math.round(new Date().getTime() / 1000) + addition;
 
     this.sendPres(this.key, {
-      room: this.roomID,
       key: this.key,
       value: JSON.stringify(value),
       expAt: expAt,
     });
 
+    if (!this.actor) {
+      this.myValue = {
+        value,
+        expAt: new Date(expAt * 1000),
+      };
+      return this.withoutExpired();
+    }
     this.cache[this.actor] = {
       value,
       expAt: new Date(expAt * 1000),
@@ -170,7 +183,6 @@ export class InnerPresenceClient<T extends any> {
       return foo;
     }
 
-    if (body.room !== this.roomID) return false;
     if (body.from === this.actor) return false; // ignore validation msgs
 
     const obj = {

--- a/src/PresenceClient.ts
+++ b/src/PresenceClient.ts
@@ -44,10 +44,11 @@ export class InnerPresenceClient<T extends any> {
     };
     this.sendPres = throttleByFirstArgument(sendPres, 40);
 
-    this.bootstrap(props.checkpoint);
+    this.bootstrap(this.actor, props.checkpoint);
   }
 
-  bootstrap(checkpoint: BootstrapState) {
+  bootstrap(actor: string, checkpoint: BootstrapState) {
+    this.actor = actor;
 
     this.cache = {
       ...this.cache,

--- a/src/PresenceClient.ts
+++ b/src/PresenceClient.ts
@@ -48,6 +48,7 @@ export class InnerPresenceClient<T extends any> {
   }
 
   bootstrap(checkpoint: BootstrapState) {
+
     this.cache = {
       ...this.cache,
       ...(checkpoint.presence[this.key] || {}),

--- a/src/RoomClient.test.ts
+++ b/src/RoomClient.test.ts
@@ -1,6 +1,7 @@
 import { RoomClient } from './RoomClient';
 import { DocumentCheckpoint } from './types';
-import { BootstrapState, LocalSession } from 'remote';
+import { AuthBundle, BootstrapState, LocalSession } from 'remote';
+import { mockAuthBundle } from './remote.test';
 
 export function mockSession(): LocalSession {
   return {
@@ -9,6 +10,14 @@ export function mockSession(): LocalSession {
     docID: 'moc docID',
     roomID: 'moc roomID',
   };
+}
+
+export function mockSessionFetch(_: {
+  authBundle: AuthBundle<any>;
+  room: string;
+  document: string;
+}): Promise<LocalSession> {
+  return Promise.resolve(mockSession());
 }
 
 export function mockCheckpoint(): DocumentCheckpoint {
@@ -33,10 +42,11 @@ export function mockBootstrapState(): BootstrapState {
 function mockRoomClient(): RoomClient {
   const session = mockSession();
   const bootstrapState = mockBootstrapState();
+  const authBundle = mockAuthBundle();
 
   return new RoomClient({
-    auth: 'xyz',
-    authCtx: null,
+    auth: authBundle.strategy,
+    authCtx: authBundle.ctx,
     session,
     wsURL: 'wss://websocket.invalid',
     docsURL: 'https://docs.invalid',

--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -94,6 +94,10 @@ export class RoomClient implements WebsocketDispatch {
         strategy: params.auth,
         ctx: params.authCtx,
       },
+      sessionFetch: (_) => {
+        //  TODO: implement re-fetching of sessions when stale
+        return Promise.resolve(params.session);
+      },
     });
     this.roomID = params.session.roomID;
     this.docID = params.bootstrapState.document.id;
@@ -402,6 +406,7 @@ export class RoomClient implements WebsocketDispatch {
 
     const p = new InnerPresenceClient<T>({
       checkpoint: this.bootstrapState,
+      actor: this.actor,
       ws: this.ws,
       key,
       bus,

--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -130,17 +130,6 @@ export class RoomClient implements WebsocketDispatch {
     this.actor = actor;
     this.bootstrapState = state;
 
-    //  make sure all clients in the checkpoint exist
-    for (const mapName of Object.keys(state.document.maps)) {
-      this.map(mapName);
-    }
-    for (const listName of Object.keys(state.document.lists)) {
-      this.list(listName);
-    }
-    for (const presenceKey of Object.keys(state.presence)) {
-      this.presence(presenceKey);
-    }
-
     for (const [_, client] of Object.entries(this.listClients)) {
       client.bootstrap(actor, state);
     }
@@ -150,8 +139,6 @@ export class RoomClient implements WebsocketDispatch {
     for (const [_, client] of Object.entries(this.presenceClients)) {
       client.bootstrap(actor, state);
     }
-
-    this.dispatchInitialUpdate();
 
     this.queueIncomingCmds = false;
     for (const [msgType, body] of this.cmdQueue) {
@@ -283,29 +270,6 @@ export class RoomClient implements WebsocketDispatch {
     if (!newClient) return;
     for (const cb of this.presenceCallbacksByKey[key] ?? []) {
       cb(newClient, body.from);
-    }
-  }
-
-  private dispatchInitialUpdate() {
-    for (const [name, client] of Object.entries(this.mapClients)) {
-      const map = client.toObject();
-      for (const cb of this.mapCallbacksByObjID[name] || []) {
-        cb(map, '__initial__');
-      }
-    }
-
-    for (const [name, client] of Object.entries(this.listClients)) {
-      const list = client.toArray();
-      for (const cb of this.listCallbacksByObjID[name] || []) {
-        cb(list, '__initial__');
-      }
-    }
-
-    for (const [key, client] of Object.entries(this.presenceClients)) {
-      const valuesByUser = client.getAll();
-      for (const cb of this.presenceCallbacksByKey[key] || []) {
-        cb(valuesByUser, '__initial__');
-      }
     }
   }
 

--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -89,7 +89,11 @@ export class RoomClient implements WebsocketDispatch {
       docsURL,
       presenceURL,
       room: roomID,
-      session: params.session,
+      document: params.docID,
+      authBundle: {
+        strategy: params.auth,
+        ctx: params.authCtx,
+      },
     });
     this.roomID = params.roomID;
     this.docID = params.bootstrapState.document.id;
@@ -501,12 +505,14 @@ export async function createRoom<A extends object>(params: {
   room: string;
   document: string;
 }): Promise<RoomClient> {
-  const session = await fetchSession(
-    params.authStrategy,
-    params.authCtx,
-    params.room,
-    params.document
-  );
+  const session = await fetchSession({
+    authBundle: {
+      strategy: params.authStrategy,
+      ctx: params.authCtx,
+    },
+    room: params.room,
+    document: params.document,
+  });
 
   const bootstrapState = await fetchBootstrapState({
     docsURL: params.docsURL,

--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -122,16 +122,17 @@ export class RoomClient implements WebsocketDispatch {
     }
   }
 
-  bootstrap(state: BootstrapState): void {
+  bootstrap(actor: string, state: BootstrapState): void {
+    this.actor = actor;
     this.bootstrapState = state;
     for (const [_, client] of Object.entries(this.listClients)) {
-      client.bootstrap(state);
+      client.bootstrap(actor, state);
     }
     for (const [_, client] of Object.entries(this.mapClients)) {
-      client.bootstrap(state);
+      client.bootstrap(actor, state);
     }
     for (const [_, client] of Object.entries(this.presenceClients)) {
-      client.bootstrap(state);
+      client.bootstrap(actor, state);
     }
     this.queueIncomingCmds = false;
     for (const [msgType, body] of this.cmdQueue) {

--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -79,23 +79,23 @@ export class RoomClient implements WebsocketDispatch {
     actor: string;
     bootstrapState: BootstrapState;
     token: string;
-    roomID: string;
-    docID: string;
+    room: string;
+    document: string;
   }) {
-    const { wsURL, docsURL, presenceURL, roomID } = params;
+    const { wsURL, docsURL, presenceURL, room, document } = params;
     this.ws = new ReconnectingWebSocket({
       dispatcher: this,
       wsURL,
       docsURL,
       presenceURL,
-      room: roomID,
-      document: params.docID,
+      room,
+      document,
       authBundle: {
         strategy: params.auth,
         ctx: params.authCtx,
       },
     });
-    this.roomID = params.roomID;
+    this.roomID = params.session.roomID;
     this.docID = params.bootstrapState.document.id;
     this.actor = params.actor;
     this.bootstrapState = params.bootstrapState;
@@ -525,8 +525,8 @@ export async function createRoom<A extends object>(params: {
     actor: session.guestReference,
     bootstrapState,
     token: session.token,
-    roomID: session.roomID,
-    docID: params.document,
+    room: params.room,
+    document: params.document,
     auth: params.authStrategy,
     authCtx: params.authCtx,
     wsURL: WS_URL,

--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -324,6 +324,7 @@ export class RoomClient implements WebsocketDispatch {
 
     const l = new InnerListClient<T>({
       checkpoint: this.bootstrapState.document,
+      roomID: this.roomID,
       docID: this.docID,
       listID: name,
       ws: this.ws,
@@ -343,6 +344,7 @@ export class RoomClient implements WebsocketDispatch {
     if (!this.bootstrapState.document.lists[name]) {
       this.ws.send('doc:cmd', {
         args: ['lcreate', this.docID, name],
+        room: this.roomID,
       });
 
       // Assume success
@@ -367,6 +369,7 @@ export class RoomClient implements WebsocketDispatch {
 
     const m = new InnerMapClient<T>({
       checkpoint: this.bootstrapState.document,
+      roomID: this.roomID,
       docID: this.docID,
       mapID: name,
       ws: this.ws,
@@ -386,6 +389,7 @@ export class RoomClient implements WebsocketDispatch {
     if (!this.bootstrapState.document.maps[name]) {
       this.ws.send('doc:cmd', {
         args: ['mcreate', this.docID, name],
+        room: this.roomID,
       });
     }
 
@@ -406,6 +410,7 @@ export class RoomClient implements WebsocketDispatch {
 
     const p = new InnerPresenceClient<T>({
       checkpoint: this.bootstrapState,
+      roomID: this.roomID,
       actor: this.actor,
       ws: this.ws,
       key,

--- a/src/remote.test.ts
+++ b/src/remote.test.ts
@@ -1,4 +1,36 @@
-import { fetchSession } from './remote';
+import { AuthResponse } from 'types';
+import { AuthBundle, fetchSession } from './remote';
+
+export function mockAuthBundle(): AuthBundle<{}> {
+  const strategy = async (_: {
+    room: string;
+    ctx: {};
+  }): Promise<AuthResponse> => {
+    return {
+      resources: [
+        {
+          reference: 'doc_123',
+          permission: 'read_write',
+          object: 'document',
+          id: '123',
+        },
+        {
+          reference: 'room_123',
+          permission: 'join',
+          object: 'room',
+          id: '123',
+        },
+      ],
+      token: 'some-token',
+      user: 'some_user_id',
+    };
+  };
+
+  return {
+    strategy,
+    ctx: {},
+  };
+}
 
 test('Test fetchSession', async () => {
   const fetcher = jest.fn(() => {
@@ -21,7 +53,11 @@ test('Test fetchSession', async () => {
     };
   });
 
-  await fetchSession(fetcher as any, {}, '123', '123');
+  await fetchSession({
+    authBundle: { strategy: fetcher as any, ctx: {} },
+    room: '123',
+    document: '123',
+  });
 
   expect(fetcher.mock.calls[0]).toEqual([
     {

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -94,13 +94,23 @@ export interface LocalSession {
   roomID: string;
 }
 
-export async function fetchSession<T extends object>(
-  strategy: AuthStrategy<T>,
-  ctx: T,
-  room: string,
-  document: string
-): Promise<LocalSession> {
+export interface AuthBundle<T extends object> {
+  strategy: AuthStrategy<T>;
+  ctx: T;
+}
+
+export async function fetchSession<T extends object>(params: {
+  authBundle: AuthBundle<T>;
+  room: string;
+  document: string;
+}): Promise<LocalSession> {
+  const {
+    authBundle: { strategy, ctx },
+    room,
+    document,
+  } = params;
   // A user defined function
+  console.log(typeof strategy);
   if (typeof strategy === 'function') {
     const result = await strategy({
       room,

--- a/src/remote.ts
+++ b/src/remote.ts
@@ -110,7 +110,6 @@ export async function fetchSession<T extends object>(params: {
     document,
   } = params;
   // A user defined function
-  console.log(typeof strategy);
   if (typeof strategy === 'function') {
     const result = await strategy({
       room,

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,7 @@ export interface DocumentCheckpoint {
   maps: { [key: string]: MapCheckpoint };
 }
 
-interface PresenceObject<T> {
+export interface PresenceObject<T> {
   expAt: Date;
   value: T;
 }

--- a/src/ws.test.ts
+++ b/src/ws.test.ts
@@ -1,4 +1,4 @@
-import { mockSession } from './RoomClient.test';
+import { mockSessionFetch } from './RoomClient.test';
 import { Prop } from 'types';
 import {
   BootstrapFetch,
@@ -6,6 +6,7 @@ import {
   WebsocketDispatch,
   WebSocketFactory,
 } from './ws';
+import { mockAuthBundle } from './remote.test';
 
 function makeTestWSFactory(
   send: Prop<WebSocket, 'send'>,
@@ -41,7 +42,9 @@ function mockReconnectingWS(
     docsURL: 'https://docs.invalid',
     presenceURL: 'https://presence.invalid',
     room: 'mock-room',
-    session: mockSession(),
+    document: 'default',
+    authBundle: mockAuthBundle(),
+    sessionFetch: mockSessionFetch,
     wsFactory: makeTestWSFactory(send, onmessage),
     bootstrapFetch: fetch,
   });
@@ -52,8 +55,7 @@ test('Reconnecting WS sends handshake message using ws factory', async (done) =>
   const onmessage = jest.fn();
   const fetch = jest.fn();
 
-  //@ts-ignore
-  const _ws = mockReconnectingWS(send, onmessage, fetch);
+  mockReconnectingWS(send, onmessage, fetch);
 
   await sendDone;
   expect(JSON.parse(send.mock.calls[0][0])['type']).toEqual(

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -110,7 +110,7 @@ export class ReconnectingWebSocket implements SuperlumeSend {
       ws.send(this.serializeMsg('guest:authenticate', session.token));
       await this.once('guest:authenticated');
 
-      ws.send(this.serializeMsg('room:join', this.room));
+      ws.send(this.serializeMsg('room:join', session.roomID));
       await this.once('room:joined');
 
       const bootstrapState = await this.bootstrapFetch({

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -359,8 +359,6 @@ async function openWS(url: string): Promise<WebSocket> {
   });
 }
 
-//  `room` is omitted because the underlying SuperlumeSend implementation injects
-//  the room id which is only known after authenticating
 export interface SuperlumeSend {
   send(msgType: 'doc:cmd', body: DocumentBody): void;
   send(msgType: 'presence:cmd', body: PresenceBody): void;

--- a/src/ws.ts
+++ b/src/ws.ts
@@ -121,7 +121,7 @@ export class ReconnectingWebSocket implements SuperlumeSend {
         token: session.token,
       });
 
-      this.dispatcher.bootstrap(bootstrapState);
+      this.dispatcher.bootstrap(session.guestReference, bootstrapState);
 
       return ws;
     });
@@ -342,7 +342,8 @@ export type ForwardedMessageBody =
 
 export interface WebsocketDispatch {
   forwardCmd(type: string, body: ForwardedMessageBody): void;
-  bootstrap(state: BootstrapState): void;
+  //  NOTE: it's possible for a future call to fetchSession ends up with a different userID
+  bootstrap(actor: string, state: BootstrapState): void;
   startQueueingCmds(): void;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1068,10 +1068,10 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
-"@roomservice/core@0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@roomservice/core/-/core-0.2.1.tgz#c54d82f53519234fa8534ab322ad6b0c93a85eb8"
-  integrity sha512-bQ9TCBEAYpeWoPF+uGgnXHwd0j07p9EJL1lp+snLacUrx+S91lzqKpY0fUTfmAyJhv6VnffaHKs4X+q3o6jAvw==
+"@roomservice/core@0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@roomservice/core/-/core-0.3.1.tgz#9f8fc93b70b94e823d2958a4dd56cbfcc7974a3d"
+  integrity sha512-X+kmnuoO5c5NjdZ/rBfY7zdHOd7SOsuR1pFq+p5WdCoVe3EIUXmPk09AGghlfO35ALrl7gua00uWrBBqSKzkbQ==
   dependencies:
     tiny-invariant "^1.1.0"
 


### PR DESCRIPTION
- adds `fetchSession` logic to `ReconnectingWebSocket`
  - currently session is still effectively passed in from `RoomClient` because clients still need a session on initialization, and we don't want to needlessly call `fetchSession` twice in the happy path
- handle actorID changes which could potentially happen if userID is random and session is fetched again