### PR TITLE
treat map.set(k, undefined) and list.set(idx, undefined) as deletes

### DIFF
--- a/src/ListClient.test.ts
+++ b/src/ListClient.test.ts
@@ -203,4 +203,21 @@ describe('list clients', () => {
 
     expect(finished.toArray()).toEqual(['a', 'b', 'c']);
   });
+
+  test('set undefined == delete', () => {
+    const l = new InnerListClient({
+      checkpoint,
+      roomID,
+      docID,
+      listID,
+      ws,
+      actor: 'me',
+      bus: new LocalBus(),
+    });
+
+    l.insertAt(0, 'a');
+    l.set(0, undefined);
+
+    expect(l.toArray()).toEqual([]);
+  });
 });

--- a/src/ListClient.ts
+++ b/src/ListClient.ts
@@ -94,6 +94,9 @@ export class InnerListClient<T extends ListObject> implements ObjectClient {
   }
 
   set<K extends number>(index: K, val: T[K]): InnerListClient<T> {
+    if (val === undefined) {
+      return this.delete(index);
+    }
     const cmd = ListInterpreter.runSet(
       this.store,
       this.meta,

--- a/src/MapClient.test.ts
+++ b/src/MapClient.test.ts
@@ -81,4 +81,11 @@ describe('InnerMapClient', () => {
     expect(map.keys.find((s) => s === 'k')).toBeUndefined();
     expect(map.toObject()['k']).toBeUndefined();
   });
+
+  test('set undefined == delete', () => {
+    map.set('k', 'v');
+    map.set('k', undefined);
+
+    expect(map.toObject()['k']).toBeUndefined();
+  });
 });

--- a/src/MapClient.ts
+++ b/src/MapClient.ts
@@ -100,6 +100,10 @@ export class InnerMapClient<T extends MapObject> implements ObjectClient {
   }
 
   set<K extends keyof T>(key: K, value: T[K]): MapClient<T> {
+    if (value === undefined) {
+      return this.delete(key);
+    }
+
     const cmd = MapInterpreter.runSet(this.store, this.meta, key as any, value);
 
     // Remote


### PR DESCRIPTION
avoids confusing behavior where setting undefined results in an empty string value on other clients (`undefined` cannot be json serialized)